### PR TITLE
Fix parallel_localization always true #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Jekyll doesn't provide native support for multi-language blogs. This plugin was 
 `gem install jekyll-polyglot` and add jekyll-polyglot to your `_config.yml` like the following:
 ```yml
 gems:
-  - jekyll-assets
+  - jekyll-polyglot
 ```
 
 ## Configuration

--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -58,9 +58,14 @@ module Jekyll
     end
 
     def process_active_language
+      old_dest = @dest
+      old_exclude = @exclude
+      @file_langs = {}
       @dest = @dest + '/' + @active_lang
       @exclude += @exclude_from_localization
       process_orig
+      @dest = old_dest
+      @exclude = old_exclude
     end
 
     # assigns natural permalinks to documents and prioritizes documents with

--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -6,11 +6,11 @@ module Jekyll
 
     def prepare
       @file_langs = {}
-      @default_lang = config['default_lang'] || 'en'
-      @languages = config['languages'] || ['en']
-      @parallel_localization = config['parallel_localization'] || true
+      @default_lang = config.fetch('default_lang', 'en')
+      @languages = config.fetch('languages', ['en'])
+      @parallel_localization = config.fetch('parallel_localization', true)
       (@keep_files << @languages - [@default_lang]).flatten!
-      @exclude_from_localization = config['exclude_from_localization'] || []
+      @exclude_from_localization = config.fetch('exclude_from_localization', [])
       @active_lang = @default_lang
     end
 


### PR DESCRIPTION
`hash[key] || default` could be replaced with `hash.fetch(key, default)` for robust code.