### PR TITLE
Translate all the collections, not just "posts"

### DIFF
--- a/lib/jekyll/polyglot/hooks/coordinate.rb
+++ b/lib/jekyll/polyglot/hooks/coordinate.rb
@@ -1,6 +1,8 @@
 # hook to coordinate blog posts and pages into distinct urls,
 # and remove duplicate multilanguage posts and pages
 Jekyll::Hooks.register :site, :post_read do |site|
-  site.posts.docs = site.coordinate_documents(site.posts.docs)
+  site.collections.each do |_, collection|
+    collection.docs = site.coordinate_documents(collection.docs)
+  end
   site.pages = site.coordinate_documents(site.pages)
 end

--- a/lib/jekyll/polyglot/hooks/process.rb
+++ b/lib/jekyll/polyglot/hooks/process.rb
@@ -1,5 +1,7 @@
 # hook to make a call to process rendered documents,
 Jekyll::Hooks.register :site, :post_render do |site|
-  site.process_documents(site.posts.docs)
+  site.collections.each do |_, collection|
+    site.process_documents(collection.docs)
+  end
   site.process_documents(site.pages)
 end


### PR DESCRIPTION
Jekyll allows to configure multiple document `collections`, while polyglot translates just `posts`.

fixes #43