### PR TITLE
updated I18n_Headers tag to default to the site.url when not provided

### DIFF
--- a/lib/jekyll/polyglot/liquid/tags/i18n-headers.rb
+++ b/lib/jekyll/polyglot/liquid/tags/i18n-headers.rb
@@ -12,13 +12,14 @@ module Jekyll
         def render(context)
           site = context.registers[:site]
           permalink = context.registers[:page]['permalink']
+          siteUrl = (@url.empty?) ? site.config['url'] : @url
           i18n = "<meta http-equiv=\"Content-Language\" content=\"#{site.active_lang}\">"
           i18n += "<link rel=\"alternate\" i18n=\"#{site.default_lang}\""\
-          " href=\"#{@url}#{permalink}\" />\n"
+          " href=\"#{siteUrl}#{permalink}\" />\n"
           site.languages.each do |lang|
             next if lang == site.default_lang
             i18n += "<link rel=\"alternate\" i18n=\"#{lang}\""\
-            " href=\"#{@url}/#{lang}#{permalink}\" />\n"
+            " href=\"#{siteUrl}/#{lang}#{permalink}\" />\n"
           end
           i18n
         end


### PR DESCRIPTION
Address #36 by making the  `I18n_Headers` tag default to the site.url when not provided with a specific route.