### PR TITLE
Recursively merge language specific `site.data`.

### DIFF
--- a/lib/jekyll/polyglot/hooks/coordinate.rb
+++ b/lib/jekyll/polyglot/hooks/coordinate.rb
@@ -5,9 +5,17 @@ Jekyll::Hooks.register :site, :post_read do |site|
 end
 
 def hook_coordinate(site)
-  if site.data.include?(site.active_lang)
-    site.data = site.data.merge(site.data[site.active_lang])
+  # Copy the language specific data, by recursively merging it with the default data.
+  # Favour active_lang first, then default_lang, then any non-language-specific data.
+  # See: https://www.ruby-forum.com/topic/142809
+  merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+  if site.data.include?(site.default_lang)
+    site.data = site.data.merge(site.data[site.default_lang], &merger)
   end
+  if site.data.include?(site.active_lang)
+    site.data = site.data.merge(site.data[site.active_lang], &merger)
+  end
+
   site.collections.each do |_, collection|
     collection.docs = site.coordinate_documents(collection.docs)
   end

--- a/spec/tests/lib/jekyll/polyglot/hooks/coordinate_spec.rb
+++ b/spec/tests/lib/jekyll/polyglot/hooks/coordinate_spec.rb
@@ -20,7 +20,9 @@ describe 'hook_coordinate' do
       )
     )
     @site.prepare
-    @site.data = { 'foo' => 'databar', 'baz' => 'databaz' }
+    @site.data = { 'foo' => 'databar', 'baz' => 'databaz', 'strings' => {
+      'banana' => 'banana',
+    }, }
     @site.data['en'] = { 'foo' => 'enbar', 'strings' => {
       'apple' => 'apple', 'ice cream' => 'ice cream',
     }, }
@@ -33,5 +35,18 @@ describe 'hook_coordinate' do
     hook_coordinate(@site)
     expect(@site.data['foo']).to eq('enbar')
     expect(@site.data['baz']).to eq('databaz')
+    expect(@site.data['strings']['ice cream']).to eq('ice cream')
+    expect(@site.data['strings']['apple']).to eq('apple')
+    expect(@site.data['strings']['banana']).to eq('banana')
+  end
+
+  it 'should fall back to the default_lang when using translated site data' do
+    @site.active_lang = 'fr'
+    hook_coordinate(@site)
+    expect(@site.data['foo']).to eq('frbar')
+    expect(@site.data['baz']).to eq('databaz')
+    expect(@site.data['strings']['ice cream']).to eq('crème glacée') # Populated from @site.data['strings'][@site.active_lang]['ice cream']
+    expect(@site.data['strings']['apple']).to eq('apple') # Populated from @site.data['strings'][@site.default_lang]['apple']
+    expect(@site.data['strings']['banana']).to eq('banana') # Populated from @site.data['strings']['apple']
   end
 end


### PR DESCRIPTION
Previously this would only overwrite the entire data files contents with
that of a language specific version. Now it merges the language specific
data file with the default, overriding whenever a new value is found in
the language specific version. This ensures that untranslated strings
revert back to their default value if a data file is only partially
translated.

Note that this doesn't try to do anything smart with arrays. If both the original data file and the language specific version contain an array, then the array from the language specific version should get chosen.

Fixes #58.