### PR TITLE
 Fix relativize_urls to only modify relative URLs

### DIFF
--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -114,7 +114,7 @@ module Jekyll
       end
       url_quoted = config['url']
       url_quoted = Regexp.quote(url_quoted) unless url_quoted.nil?
-      %r{href=\"(?:#{url_quoted})?#{@baseurl}\/((?:#{regex}[^,'\"\s\/?\.#]+\.?)*(?:\/[^\]\[\)\(\"\'\s]*)?)\"}
+      %r{href=\"?#{@baseurl}\/((?:#{regex}[^,'\"\s\/?\.#]+\.?)*(?:\/[^\]\[\)\(\"\'\s]*)?)\"}
     end
 
     def relativize_urls(doc)


### PR DESCRIPTION
Sorry for the long winded PR for a one-liner fix.  Just wanting to clarify why I propose the change, as I was trying to debug why my absolute URLs were being mangled for way too long and I figured others might run into the same issues.  Thanks again for the great plugin Untra!
___
What: I changed a regex to match only relative URLs, as it's comment states it
should do.

Why: The reason I made this change was because there is an error where some URLs
can be 'doubled up' if they are localized.  For example, on the current demo
page for [Polyglot](http://polyglot.untra.io/es/seo/) if you load the page in a
non-default language (for example, Spanish), URLs will be localized twice.  For
example, see the head section where the I18n_Headers liquid tag runs; instead of
listing an alternative url for this post in each of languages it mistakenly
prepends '/es' to each.  So, on the Spanish version of the page, the German lang
alternative link looks like 'http://polyglot.untra.io/es/de/seo/'.  Note the
incorrect '/es' in the URL.

Cause: The relative URL parser, which is meant to localize relative URLs, will
*also* parse absolute URLs that are on the same domain as 'site.url'.  This
causes 2 issues:
1. Some resources, such as I18n localization links should ALWAYS be
absolute URLs, but this parser converts them into a relative URL, because they
contain the site.url value.
2. It localizes absolute links, which, as shown in the I18n_Headers example
is an apparently unintended, and incorrect action.

Notes: If users want to have their links localized they should be sure to
localize using local URLs as shown in the [How To Use It section](https://github.com/untra/polyglot#relativized-local-urls)