### PR TITLE
remove extra space, in case of default language.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :test do
   gem 'nokogiri'
   gem 'rspec'
   gem 'rspec-mocks'
-  gem 'rubocop', :github => 'bbatsov/rubocop', :branch => :master, :require => false
+  gem 'rubocop'
 end
 
 gem 'github-pages', '134'

--- a/lib/jekyll/polyglot/liquid/tags/i18n-headers.rb
+++ b/lib/jekyll/polyglot/liquid/tags/i18n-headers.rb
@@ -15,7 +15,7 @@ module Jekyll
           site_url = @url.empty? ? site.config['url'] : @url
           i18n = "<meta http-equiv=\"Content-Language\" content=\"#{site.active_lang}\">\n"
           i18n += "<link rel=\"alternate\" hreflang=\"#{site.default_lang}\" "\
-          "href=\" #{site_url}#{permalink}\"/>\n"
+          "href=\"#{site_url}#{permalink}\"/>\n"
           site.languages.each do |lang|
             next if lang == site.default_lang
             i18n += "<link rel=\"alternate\" hreflang=\"#{lang}\" "\


### PR DESCRIPTION
This creates problem with `html-proofer` package. As generated html links contains space at the beginning.

```
<link rel="alternate" hreflang="nl" href=" https://medigroup.nl/"/>
<link rel="alternate" hreflang="en" href="https://medigroup.nl/en/"/>
```