### PR TITLE
fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ sudo: false
 #
 
 rvm:
-  - &ruby1 2.5.5
-  - &ruby1 2.4.1
-  - &ruby2 2.3.4
-  - &ruby3 2.2.7
-  - &rhead ruby-head
+  - &ruby1 2.6.3
+  - &ruby2 2.5.5
+  - &ruby3 2.4.1
+  - &ruby4 2.3.4
+  - &ruby5 2.2.7
 
 #
 


### PR DESCRIPTION
* latest ruby head is currently [choking other ruby gems](https://github.com/rubocop-hq/rubocop/issues/7124), remove latest from travis so CI lights turn green for contributors