### PR TITLE
automatically add trailing / to exclude_from_localization dir items

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,8 @@
+
+rspec:
+  image: debian:buster
+  script:
+    - apt-get update
+    - apt-get -qy dist-upgrade
+    - apt-get -qy install jekyll rake ruby-minitest ruby-nokogiri ruby-rspec ruby-rspec-mocks rubocop
+    - rspec

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ In your `_config.yml` file, add the following preferences
 ```YAML
 languages: ["en", "sv", "de", "fr"]
 default_lang: "en"
-exclude_from_localization: ["javascript", "images", "css"]
+exclude_from_localization: ["javascript", "images", "css", "README.md"]
 parallel_localization: true
 ```
 These configuration preferences indicate
 - what i18n languages you wish to support
 - what is your default "fallback" language for your content
-- what root level folders are you excluding from localization
+- what root level files/folders are excluded from localization, based
+  on if their paths start with any of the excluded regexp substrings
 - whether to run language processing in parallel or serial
 
 ## How To Use It

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ These configuration preferences indicate
   on if their paths start with any of the excluded regexp substrings
 - whether to run language processing in parallel or serial
 
+The optional `lang_from_path: true` option enables getting page
+language from the first or second path segment, e.g _de/first-one.md_,
+__posts/zh_Hans_HK/use-second-segment.md_.
+
+
 ## How To Use It
 When adding new posts and pages, add to the YAML front matter:
 ```

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ let us know if you make a multilingual blog you want to share:
 * [Polyglot example project website](http://polyglot.untra.io)
 * [LogRhythm Corporate Website](http://logrhythm.com)
 * [All Over Earth](https://allover.earth/)
-* [Hanare Cafe in Toshijima, Japan](https://hanarecafe2019.netlify.com)
+* [Hanare Cafe in Toshijima, Japan](https://hanarecafe.com)
+* [F-Droid](https://f-droid.org)
 
 ## Compatibility
 Currently supports Jekyll 3.0 .

--- a/spec/tests/lib/jekyll/polyglot/hooks/coordinate_spec.rb
+++ b/spec/tests/lib/jekyll/polyglot/hooks/coordinate_spec.rb
@@ -1,53 +1,61 @@
+# coding: utf-8
 require 'rspec/helper'
 require 'ostruct'
+require 'fileutils'
+require 'tmpdir'
 require_relative '../../../../../../lib/jekyll/polyglot/hooks/coordinate'
 # rubocop:disable BlockLength, LineLength
-describe 'hook_coordinate' do
-  before do
-    @config = Jekyll::Configuration::DEFAULTS.dup
-    @langs = ['en', 'fr']
-    @default_lang = 'en'
-    @exclude_from_localization = ['javascript', 'images', 'css']
-    @config['langs'] = @langs
-    @config['default_lang'] = @default_lang
-    @config['exclude_from_localization'] = @exclude_from_localization
-    @parallel_localization = @config['parallel_localization'] || true
-    @site = Site.new(
-      Jekyll.configuration(
-        'languages'                 => @langs,
-        'default_lang'              => @default_lang,
-        'exclude_from_localization' => @exclude_from_localization,
-        'source'                    => File.expand_path('./fixtures', __FILE__)
+Dir.mktmpdir do |dir|
+  FileUtils.mkdir_p 'css'
+  FileUtils.mkdir_p 'images'
+  FileUtils.mkdir_p 'javascript'
+  describe 'hook_coordinate' do
+    before do
+      @config = Jekyll::Configuration::DEFAULTS.dup
+      @langs = ['en', 'fr']
+      @default_lang = 'en'
+      @exclude_from_localization = ['javascript', 'images', 'css']
+      @config['langs'] = @langs
+      @config['default_lang'] = @default_lang
+      @config['exclude_from_localization'] = @exclude_from_localization
+      @parallel_localization = @config['parallel_localization'] || true
+      @site = Site.new(
+        Jekyll.configuration(
+          'languages'                 => @langs,
+          'default_lang'              => @default_lang,
+          'exclude_from_localization' => @exclude_from_localization,
+          'source'                    => File.expand_path('./fixtures', __FILE__)
+        )
       )
-    )
-    @site.prepare
-    @site.data = { 'foo' => 'databar', 'baz' => 'databaz', 'strings' => {
-      'banana' => 'banana',
-    }, }
-    @site.data['en'] = { 'foo' => 'enbar', 'strings' => {
-      'apple' => 'apple', 'ice cream' => 'ice cream',
-    }, }
-    @site.data['fr'] = { 'foo' => 'frbar', 'strings' => {
-      'ice cream' => 'crème glacée',
-    }, }
-  end
+      @site.prepare
+      @site.data = { 'foo' => 'databar', 'baz' => 'databaz', 'strings' => {
+                       'banana' => 'banana',
+                     }, }
+      @site.data['en'] = { 'foo' => 'enbar', 'strings' => {
+                             'apple' => 'apple', 'ice cream' => 'ice cream',
+                           }, }
+      @site.data['fr'] = { 'foo' => 'frbar', 'strings' => {
+                             'ice cream' => 'crème glacée',
+                           }, }
+    end
 
-  it 'should merge the site.data.active_lang to the site.data' do
-    hook_coordinate(@site)
-    expect(@site.data['foo']).to eq('enbar')
-    expect(@site.data['baz']).to eq('databaz')
-    expect(@site.data['strings']['ice cream']).to eq('ice cream')
-    expect(@site.data['strings']['apple']).to eq('apple')
-    expect(@site.data['strings']['banana']).to eq('banana')
-  end
+    it 'should merge the site.data.active_lang to the site.data' do
+      hook_coordinate(@site)
+      expect(@site.data['foo']).to eq('enbar')
+      expect(@site.data['baz']).to eq('databaz')
+      expect(@site.data['strings']['ice cream']).to eq('ice cream')
+      expect(@site.data['strings']['apple']).to eq('apple')
+      expect(@site.data['strings']['banana']).to eq('banana')
+    end
 
-  it 'should fall back to the default_lang when using translated site data' do
-    @site.active_lang = 'fr'
-    hook_coordinate(@site)
-    expect(@site.data['foo']).to eq('frbar')
-    expect(@site.data['baz']).to eq('databaz')
-    expect(@site.data['strings']['ice cream']).to eq('crème glacée') # Populated from @site.data['strings'][@site.active_lang]['ice cream']
-    expect(@site.data['strings']['apple']).to eq('apple') # Populated from @site.data['strings'][@site.default_lang]['apple']
-    expect(@site.data['strings']['banana']).to eq('banana') # Populated from @site.data['strings']['apple']
+    it 'should fall back to the default_lang when using translated site data' do
+      @site.active_lang = 'fr'
+      hook_coordinate(@site)
+      expect(@site.data['foo']).to eq('frbar')
+      expect(@site.data['baz']).to eq('databaz')
+      expect(@site.data['strings']['ice cream']).to eq('crème glacée') # Populated from @site.data['strings'][@site.active_lang]['ice cream']
+      expect(@site.data['strings']['apple']).to eq('apple') # Populated from @site.data['strings'][@site.default_lang]['apple']
+      expect(@site.data['strings']['banana']).to eq('banana') # Populated from @site.data['strings']['apple']
+    end
   end
 end

--- a/spec/tests/lib/jekyll/polyglot/hooks/coordinate_spec.rb
+++ b/spec/tests/lib/jekyll/polyglot/hooks/coordinate_spec.rb
@@ -14,7 +14,7 @@ Dir.mktmpdir do |dir|
       @config = Jekyll::Configuration::DEFAULTS.dup
       @langs = ['en', 'fr']
       @default_lang = 'en'
-      @exclude_from_localization = ['javascript', 'images', 'css']
+      @exclude_from_localization = ['javascript', 'images', 'css/', 'README.md']
       @config['langs'] = @langs
       @config['default_lang'] = @default_lang
       @config['exclude_from_localization'] = @exclude_from_localization
@@ -37,6 +37,10 @@ Dir.mktmpdir do |dir|
       @site.data['fr'] = { 'foo' => 'frbar', 'strings' => {
                              'ice cream' => 'crème glacée',
                            }, }
+    end
+
+    it 'should have trailing / on all dir entries in exclude_from_localization' do
+      expect(@site.exclude_from_localization).to eq(["javascript/", "images/", "css/", "README.md"])
     end
 
     it 'should merge the site.data.active_lang to the site.data' do

--- a/spec/tests/lib/jekyll/polyglot/patches/jekyll/site_spec.rb
+++ b/spec/tests/lib/jekyll/polyglot/patches/jekyll/site_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rspec/helper'
 require 'ostruct'
 # rubocop:disable BlockLength, LineLength
@@ -6,7 +7,7 @@ describe Site do
     @config = Jekyll::Configuration::DEFAULTS.dup
     @langs = ['en', 'sp', 'fr', 'de']
     @default_lang = 'en'
-    @exclude_from_localization = ['javascript', 'images', 'css']
+    @exclude_from_localization = ['javascript/', 'images/', 'css/']
     @config['langs'] = @langs
     @config['default_lang'] = @default_lang
     @config['exclude_from_localization'] = @exclude_from_localization


### PR DESCRIPTION
- [X] The pull request is complete according to the [Definition of Done](https://sites.google.com/leviy.com/development/development/definition-of-done)
  - [X] Automated tests are written according to the [test plan](https://docs.google.com/document/d/106bwyTS-gIrT7edLW4_5pCl6DSDaZBEMiiyBw1za0R8/edit#heading=h.5ybg7xjjzlkj)
  - [X] The documentation is up-to-date
  - [X] Deployment automation includes newly introduced environment variables and credentials are added to the credentials.fact file of all servers
- [X] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog

Right now, this is a simple "starts with" check against the relative path. If there are simple entries like "js" or "po" those will match lots of things like "jsoup" or "posts".  If the item is a dir, then automatically add a trailing slash to avoid this ambiguity.
