### PR TITLE
trigger :polyglot :post_write hook

### DIFF
--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -59,6 +59,7 @@ module Jekyll
           process_language lang
         end
       end
+      Jekyll::Hooks.trigger :polyglot, :post_write
     end
 
     alias_method :site_payload_orig, :site_payload


### PR DESCRIPTION
## 🔤 Polyglot PR

With `parallel_localization`, hooks like these:

```rb
Jekyll::Hooks.register :site, :post_write do |site|
  ...
end
```

run in all the child processes.

Currently, if you want a `:post_write` hook that only runs once, after all languages have been processed, you need to figure out which of the hooks is the last one to run (not that hard with a lock file, but not ideal).

This adds a custom `:post_write` hook that runs exactly once, after all languages been processed (whether or not `parallel_localization` is used):

```rb
Jekyll::Hooks.register :polyglot, :post_write do |site|
  ...
end
```

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [ ] If modifying code, at least one test has been added to the suite
