### PR TITLE
Allow #anchor links in relativized urls

### DIFF
--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -190,7 +190,7 @@ module Jekyll
         end
       end
       start = disabled ? 'ferh' : 'href'
-      %r{#{start}=\"?#{@baseurl}\/((?:#{regex}[^,'\"\s\/?\.#]+\.?)*(?:\/[^\]\[\)\(\"\'\s]*)?)\"}
+      %r{#{start}=\"?#{@baseurl}\/((?:#{regex}[^,'\"\s\/?\.]+\.?)*(?:\/[^\]\[\)\(\"\'\s]*)?)\"}
     end
 
     # a regex that matches absolute urls in a html document
@@ -208,7 +208,7 @@ module Jekyll
         end
       end
       start = disabled ? 'ferh' : 'href'
-      %r{(?<!hreflang="#{@default_lang}" )#{start}=\"?#{url}#{@baseurl}\/((?:#{regex}[^,'\"\s\/?\.#]+\.?)*(?:\/[^\]\[\)\(\"\'\s]*)?)\"}
+      %r{(?<!hreflang="#{@default_lang}" )#{start}=\"?#{url}#{@baseurl}\/((?:#{regex}[^,'\"\s\/?\.]+\.?)*(?:\/[^\]\[\)\(\"\'\s]*)?)\"}
     end
 
     def relativize_urls(doc, regex)

--- a/spec/jekyll/polyglot/patches/jekyll/site_spec.rb
+++ b/spec/jekyll/polyglot/patches/jekyll/site_spec.rb
@@ -66,6 +66,8 @@ describe Site do
         expect(@relative_url_regex).to match "href=\"#{baseurl}/words-1-with-2-numbers-34/\""
         expect(@relative_url_regex).to match "href=\"#{baseurl}/\""
         expect(@relative_url_regex).to match "href=\"#{baseurl}/purchase/product/1234-business\""
+        expect(@relative_url_regex).to match "href=\"#{baseurl}/#about\""
+        expect(@relative_url_regex).to match "href=\"#{baseurl}/about/#team\""
       end
     end
     it 'must match with an empty baseurl' do
@@ -76,6 +78,8 @@ describe Site do
       expect(@relative_url_regex).to match 'href="/2016/words-1-with-2-numbers-34/"'
       expect(@relative_url_regex).to match 'href="/"'
       expect(@relative_url_regex).to match 'href="/purchase/product/1234-business"'
+      expect(@relative_url_regex).to match 'href="/#about"'
+      expect(@relative_url_regex).to match 'href="/about/#team"'
     end
     it 'must not match external urls' do
       @relative_url_regex = @site.relative_url_regex
@@ -108,6 +112,8 @@ describe Site do
         expect(@relative_url_regex).to_not match "href=\"#{lang}/about/\""
         expect(@relative_url_regex).to_not match "href=\"#{lang}/\""
         expect(@relative_url_regex).to_not match "href=\"#{lang}/purchase/product/1234-business\""
+        expect(@relative_url_regex).to_not match "href=\"#{lang}/#about\""
+        expect(@relative_url_regex).to_not match "href=\"#{lang}/about/#team\""
       end
     end
 
@@ -134,6 +140,8 @@ describe Site do
           expect(@relative_url_regex).to match "ferh=\"#{baseurl}/words-1-with-2-numbers-34/\""
           expect(@relative_url_regex).to match "ferh=\"#{baseurl}/\""
           expect(@relative_url_regex).to match "ferh=\"#{baseurl}/purchase/product/1234-business\""
+          expect(@relative_url_regex).to match "ferh=\"#{baseurl}/#about\""
+          expect(@relative_url_regex).to match "ferh=\"#{baseurl}/about/#team\""
         end
       end
     end


### PR DESCRIPTION
## 🔤 Polyglot PR

This removes the explicit exclusion of "#" characters after a folder slash in the relative_url_regex and absolute_url_regex regexes.  Enables proper language folder insertion of anchor links such as:
/#features
/about/#team

Fixes #149 
## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [x] If modifying code, at least one test has been added to the suite
