### PR TITLE
Bugfix frozenstring

### DIFF
--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -214,25 +214,25 @@ module Jekyll
     def relativize_urls(doc, regex)
       return if doc.output.nil?
 
-      doc.output.gsub!(regex, "href=\"#{@baseurl}/#{@active_lang}/" + '\1"')
+      doc.output.gsub(regex, "href=\"#{@baseurl}/#{@active_lang}/" + '\1"')
     end
 
     def relativize_absolute_urls(doc, regex, url)
       return if doc.output.nil?
 
-      doc.output.gsub!(regex, "href=\"#{url}#{@baseurl}/#{@active_lang}/" + '\1"')
+      doc.output.gsub(regex, "href=\"#{url}#{@baseurl}/#{@active_lang}/" + '\1"')
     end
 
     def correct_nonrelativized_absolute_urls(doc, regex, url)
       return if doc.output.nil?
 
-      doc.output.gsub!(regex, "href=\"#{url}#{@baseurl}/" + '\1"')
+      doc.output.gsub(regex, "href=\"#{url}#{@baseurl}/" + '\1"')
     end
 
     def correct_nonrelativized_urls(doc, regex)
       return if doc.output.nil?
 
-      doc.output.gsub!(regex, "href=\"#{@baseurl}/" + '\1"')
+      doc.output.gsub(regex, "href=\"#{@baseurl}/" + '\1"')
     end
   end
 end

--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -213,20 +213,23 @@ module Jekyll
 
     def relativize_urls(doc, regex)
       return if doc.output.nil?
-
-      doc.output.gsub(regex, "href=\"#{@baseurl}/#{@active_lang}/" + '\1"')
+      modified_output = doc.output.dup
+      modified_output.gsub!(regex, "href=\"#{@baseurl}/#{@active_lang}/" + '\1"')
+      doc.output = modified_output
     end
 
     def relativize_absolute_urls(doc, regex, url)
       return if doc.output.nil?
-
-      doc.output.gsub(regex, "href=\"#{url}#{@baseurl}/#{@active_lang}/" + '\1"')
+      modified_output = doc.output.dup
+      modified_output.gsub!(regex, "href=\"#{url}#{@baseurl}/#{@active_lang}/" + '\1"')
+      doc.output = modified_output
     end
 
     def correct_nonrelativized_absolute_urls(doc, regex, url)
       return if doc.output.nil?
-
-      doc.output.gsub(regex, "href=\"#{url}#{@baseurl}/" + '\1"')
+      modified_output = doc.output.dup
+      modified_output.gsub!(regex, "href=\"#{url}#{@baseurl}/" + '\1"')
+      doc.output = modified_output
     end
 
     def correct_nonrelativized_urls(doc, regex)
@@ -234,7 +237,6 @@ module Jekyll
       modified_output = doc.output.dup
       modified_output.gsub!(regex, "href=\"#{@baseurl}/" + '\1"')
       doc.output = modified_output
-      # doc.output.gsub(regex, "href=\"#{@baseurl}/" + '\1"')
     end
   end
 end

--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -231,8 +231,10 @@ module Jekyll
 
     def correct_nonrelativized_urls(doc, regex)
       return if doc.output.nil?
-
-      doc.output.gsub(regex, "href=\"#{@baseurl}/" + '\1"')
+      modified_output = doc.output.dup
+      modified_output.gsub!(regex, "href=\"#{@baseurl}/" + '\1"')
+      doc.output = modified_output
+      # doc.output.gsub(regex, "href=\"#{@baseurl}/" + '\1"')
     end
   end
 end


### PR DESCRIPTION
## 🔤 Polyglot PR

> Description here

<!-- thanks for making a pull request! you are a handsome and kind individual, and you should be proud of your accomplishments -->

try to fix part of the problems from #107 

I met the frozen string error issue. The error was from `lib/jekyll/polyglot/patches/jekyll/site.rb` when setting the `sourcemap: never`.

I found the problem originates from the url replacement functions from line 214. `gsub!` function cannot be used for frozen strings while some doc from docs in `process_documents` function are frozen strings.

So I change the approach of replacement from `gsub!` to define a temp variable in replacement functions and replace the doc.output with it.

example:

```ruby

#old
    def correct_nonrelativized_urls(doc, regex)
      return if doc.output.nil?
      doc.gsub!(regex, "href=\"#{@baseurl}/" + '\1"')
    end
#new
    def correct_nonrelativized_urls(doc, regex)
      return if doc.output.nil?
      modified_output = doc.output.dup
      modified_output.gsub!(regex, "href=\"#{@baseurl}/" + '\1"')
      doc.output = modified_output
    end

```
I'm not familiar with Ruby. I asked ChatGPT and read some documents to resolve this. 

I'm not sure how to test my code because I have only one test case which is my website and it works well. Please review the code, thanks!

![add a sweet (optional) meme](giphy-url.gif)

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [ ] If modifying code, at least one test has been added to the suite
