### PR TITLE
Optionally use an ad-hoc id for language file identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,34 @@ In short:
 * Don't overthink it, :wink:
 
 
+#### Using different permalinks per language
+
+Optionally, for those who may want different URLs on different laguages, translations may be identified by specifying a `lang_id` in the frontmatter.
+
+If available, polyglot will use `lang_id` and will default to the `permalink` otherwise.
+
+As an example, you may have an about page located in `/about/` while being in `/acerca-de/` in Spanish just by changing the permalink and specifying a `lang_id` that will link the files as translations:
+```md
+---
+title: About
+permalink: /about/
+lang: en
+lang_id: about
+---
+This is us!
+```
+
+```md
+---
+title: Acerca de
+permalink: /acerca-de/
+lang: es
+lang_id: about
+---
+Estos somos nosotros!
+```
+
+
 #### Fallback Language Support
 Lets say you are building your website. You have an `/about/` page written in *english*, *german* and
 *swedish*. You are also supporting a *french* website, but you never designed a *french* version of your `/about/` page!

--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -130,16 +130,18 @@ module Jekyll
         lang = doc.data['lang'] || derive_lang_from_path(doc) || @default_lang
         lang_exclusive = doc.data['lang-exclusive'] || []
         url = doc.url.gsub(regex, '/')
-        doc.data['permalink'] = url
+        lang_id = doc.data['lang_id'] || url
+        doc.data['permalink'] = url unless defined?(doc.data['permalink'])
+
         # skip this document if it has already been processed
-        next if @file_langs[url] == @active_lang
+        next if @file_langs[lang_id] == @active_lang
         # skip this document if it has a fallback and it isn't assigned to the active language
-        next if @file_langs[url] == @default_lang && lang != @active_lang
+        next if @file_langs[lang_id] == @default_lang && lang != @active_lang
         # skip this document if it has lang-exclusive defined and the active_lang is not included
         next if !lang_exclusive.empty? && !lang_exclusive.include?(@active_lang)
 
-        approved[url] = doc
-        @file_langs[url] = lang
+        approved[lang_id] = doc
+        @file_langs[lang_id] = lang
       end
       approved.values
     end

--- a/spec/fixture/pages/en.menu.md
+++ b/spec/fixture/pages/en.menu.md
@@ -1,7 +1,8 @@
 ---
 title: Menu
-permalink: menu
+permalink: the-menu
 lang: en
+lang_id: menu
 ---
 
 # menu

--- a/spec/fixture/pages/es.menu.md
+++ b/spec/fixture/pages/es.menu.md
@@ -1,7 +1,8 @@
 ---
 title: Menu
-permalink: menu
+permalink: el-menu
 lang: es
+lang_id: menu
 ---
 
 # menú

--- a/spec/fixture/pages/fr.menu.md
+++ b/spec/fixture/pages/fr.menu.md
@@ -1,7 +1,8 @@
 ---
 title: Menu
-permalink: menu
+permalink: le-menu
 lang: fr
+lang_id: fr
 ---
 
 # français menu

--- a/spec/jekyll/polyglot/hooks/coordinate_spec.rb
+++ b/spec/jekyll/polyglot/hooks/coordinate_spec.rb
@@ -95,6 +95,15 @@ Dir.mktmpdir do |_|
         @site.process_language 'fr'
         expect(@site.pages.map { |doc| doc.name }).not_to include('es.samba.md')
       end
+
+      it 'should respect permalinks when lang_id is specified' do
+        @site.process_language 'en'
+        expect(@site.pages.select { |doc| doc.name == 'en.menu.md' }.permalink).to eq('the-menu')
+        @site.process_language 'fr'
+        expect(@site.pages.select { |doc| doc.name == 'en.menu.md' }.permalink).to eq('le-menu')
+        @site.process_language 'es'
+        expect(@site.pages.select { |doc| doc.name == 'en.menu.md' }.permalink).to eq('el-menu')
+      end
     end
   end
 end


### PR DESCRIPTION
## 🔤 Polyglot PR

> Description here

This is a proposal for solving issues https://github.com/untra/polyglot/issues/98 and https://github.com/untra/polyglot/issues/33 while trying to not break compatibility with previous versions.

The PR keeps Polyglot working as it used to be unless you provide a lang_id key in the front matter of a page. When you use a lang_id key then it will be used to identify documents as translations of the same content without overriding the permalink field.

![Yessss](https://media1.giphy.com/media/S3Ot3hZ5bcy8o/giphy.gif?cid=ecf05e47wozdwtgc9kuhlwj4qq9rl03tepenrsnih8g3r7o1&ep=v1_gifs_search&rid=giphy.gif&ct=g)

This is my first PR to the project and it is work in progress, please provide feedback on whether this is desired and/or what should improve to be merged. Thanks!

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [x] If modifying code, at least one test has been added to the suite
