### PR TITLE
Add other lang permalinks to doc data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,8 +18,10 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.16.3)
+    ffi (1.16.3-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
     google-protobuf (3.24.4)
+    google-protobuf (3.24.4-x64-mingw-ucrt)
     google-protobuf (3.24.4-x86_64-darwin)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
@@ -61,6 +63,8 @@ GEM
     minitest (5.16.3)
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.15.4-x64-mingw-ucrt)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
@@ -112,6 +116,8 @@ GEM
     sass-embedded (1.68.0)
       google-protobuf (~> 3.23)
       rake (>= 13.0.0)
+    sass-embedded (1.68.0-x64-mingw-ucrt)
+      google-protobuf (~> 3.23)
     sass-embedded (1.68.0-x86_64-darwin)
       google-protobuf (~> 3.23)
     terminal-table (3.0.2)
@@ -121,6 +127,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw-ucrt
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ In short:
 * Don't overthink it, :wink:
 
 
+### Translation permalink information in page
+_New in 1.7.1_
+
+Whenever `page_id` frontmatter properties are used to identify translations, permalink information for the available languages is available in `permalink_lang`.
+This is useful in order to generate language menús and even localization meta information without redirections!
+
+Sample code for meta link generation:
+```
+{% for lang in site.languages %}
+  {% capture lang_href %}{{site.baseurl}}/{% if lang != site.default_lang %}{{ lang }}/{% endif %}{% if page.permalink_lang[lang] != '/' %}{{page.permalink_lang[lang]}}{% endif %}{% endcapture %}
+  <link rel="alternate" hreflang="{{ lang }}" {% static_href %}href="{{ lang_href }}"{% endstatic_href %} />
+{% endfor %}
+```
+
+
 #### Using different permalinks per language
 _New in 1.7.0_
 

--- a/lib/jekyll/polyglot/liquid/tags/i18n_headers.rb
+++ b/lib/jekyll/polyglot/liquid/tags/i18n_headers.rb
@@ -12,6 +12,7 @@ module Jekyll
         def render(context)
           site = context.registers[:site]
           permalink = context.registers[:page]['permalink']
+          permalink_lang = context.registers[:page]['permalink_lang']
           site_url = @url.empty? ? site.config['url'] : @url
           i18n = "<meta http-equiv=\"Content-Language\" content=\"#{site.active_lang}\">\n"
           i18n += "<link rel=\"alternate\" hreflang=\"#{site.default_lang}\" "\
@@ -19,8 +20,9 @@ module Jekyll
           site.languages.each do |lang|
             next if lang == site.default_lang
 
+            url = permalink_lang && permalink_lang[lang] ? permalink_lang[lang] : permalink
             i18n += "<link rel=\"alternate\" hreflang=\"#{lang}\" "\
-            "href=\"#{site_url}/#{lang}#{permalink}\"/>\n"
+            "href=\"#{site_url}/#{lang}/#{url}\"/>\n"
           end
           i18n
         end

--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -149,6 +149,7 @@ module Jekyll
         @file_langs[page_id] = lang
       end
       approved.values.each {|doc| assignPageRedirects(doc, docs) }
+      approved.values.each {|doc| assignPageLanguagePermalinks(doc, docs) }
       approved.values
     end
 
@@ -163,6 +164,20 @@ module Jekyll
         end
         redirects = redirectDocs.map { |dd| dd.data['permalink'] }
         doc.data['redirect_from'] = redirects
+      end
+    end
+
+    def assignPageLanguagePermalinks(doc, docs)
+      pageId = doc.data['page_id']
+      if !pageId.nil? && !pageId.empty?
+        unless doc.data['permalink_lang'] then doc.data['permalink_lang'] = {} end
+        permalinkDocs = docs.select do |dd|
+          dd.data['page_id'] == pageId
+        end
+        permalinkDocs.each do |dd|
+          doclang = dd.data['lang'] || derive_lang_from_path(dd) || @default_lang
+          doc.data['permalink_lang'][doclang] = dd.data['permalink']
+        end
       end
     end
 

--- a/spec/jekyll/polyglot/hooks/coordinate_spec.rb
+++ b/spec/jekyll/polyglot/hooks/coordinate_spec.rb
@@ -108,6 +108,16 @@ Dir.mktmpdir do |_|
         expect(@site.pages.select { |doc| doc.name == 'fr.menu.md' }.first().permalink).to eq('le-menu')
         expect(@site.pages.select { |doc| doc.name == 'fr.members.md' }.first().permalink).to eq('members')
       end
+      
+      it 'should contain permalink_lang when page_id is specified' do
+        @site.process_language 'en'
+        menu_permalink_lang = @site.pages.select { |doc| doc.name == 'en.menu.md' }.first().data['permalink_lang']
+        expect(menu_permalink_lang).to have_attributes(size: 3)
+        expect(menu_permalink_lang.keys).to match_array(@site.config['languages'])
+        expect(menu_permalink_lang['en']).to eq('the-menu')
+        expect(menu_permalink_lang['es']).to eq('el-menu')
+        expect(menu_permalink_lang['fr']).to eq('le-menu')
+      end
     end
   end
 end


### PR DESCRIPTION
## 🔤 Polyglot PR

> Description here

Adding other lang permalinks to a page may allow the user to generate direct links to translations without redirects. I think that SEO focused sites may benefit from this! :D

Let me know what you think and if how could I improve this!

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [ ] If modifying code, at least one test has been added to the suite
