### PR TITLE
[permalink] Ensure that the permalink is correctly set #199

### DIFF
--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -138,7 +138,7 @@ module Jekyll
         lang_exclusive = doc.data['lang-exclusive'] || []
         url = doc.url.gsub(regex, '/')
         page_id = doc.data['page_id'] || url
-        doc.data['permalink'] = url unless defined?(doc.data['permalink'])
+        doc.data['permalink'] = url if doc.data['permalink'].to_s.empty? && !doc.data['lang'].to_s.empty?
 
         # skip entirely if nothing to check
         next if @file_langs.nil?
@@ -185,7 +185,7 @@ module Jekyll
       end
     end
 
-    # performs any necesarry operations on the documents before rendering them
+    # performs any necessary operations on the documents before rendering them
     def process_documents(docs)
       # return if @active_lang == @default_lang
 


### PR DESCRIPTION
It ensures that the permalink_lang attribute is set correctly and can be used when a permalink attribute is set at the site level. It is, indeed, not enough to check if the permalink is undefined. The permalink might be set to empty. Moreover, we should check that the page has a lang attribute isn't empty as well.

## 🔤 Polyglot PR

In cases where no permalink is set in the post or page, but there is a permalink set at the site level, this fix ensures that the permalink_lang attribute is set correctly.

Then, a language switch can be simply implemented, example below:

```liquid
<div class="language">
  {% for language in site.languages %}
    {% if language != site.default_lang %}
      {% assign url = language | append: page.permalink_lang[language] %}
    {% else %}
      {% assign url = page.permalink_lang[language] %}
    {% endif %}
    <a class="nav-link" {% static_href %} href="{{url | relative_url}}" {% endstatic_href %}>
      {{ site.data.translations.languages[language] }}
    </a>
  {% endfor %}
</div>
```

**Note:** I didn't create a test case, because I'm not familiar with Ruby and the testing mechanism. 😢

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [ ] If modifying code, at least one test has been added to the suite
