### PR TITLE
fix: Default language should use the similar url pattern with other l…

### DIFF
--- a/lib/jekyll/polyglot/liquid/tags/i18n_headers.rb
+++ b/lib/jekyll/polyglot/liquid/tags/i18n_headers.rb
@@ -16,7 +16,7 @@ module Jekyll
           site_url = @url.empty? ? site.config['url'] : @url
           i18n = "<meta http-equiv=\"Content-Language\" content=\"#{site.active_lang}\">\n"
           i18n += "<link rel=\"alternate\" hreflang=\"#{site.default_lang}\" "\
-          "href=\"#{site_url}#{permalink}\"/>\n"
+          "href=\"#{site_url}/#{permalink}\"/>\n"
           site.languages.each do |lang|
             next if lang == site.default_lang
 


### PR DESCRIPTION
…anguages

## 🔤 Polyglot PR

> 
If the permalink of a page is assigned to '/xxx', the hreflang for other languages are wrong, like <link rel="alternate" hreflang="es" href="https://polyglot.untra.io/es//seo/"/>
If the permalink of a page is assigned to 'xxx/', the hreflang for default_lang is wrong.
We can see the bug from the source code of https://polyglot.untra.io/seo/.

This href url is wrong.
`<link rel="alternate" hreflang="en" href="https://polyglot.untra.ioseo/"/>`

We should add a slash for the default language in the template.

<!-- thanks for making a pull request! you are a handsome and kind individual, and you should be proud of your accomplishments -->

![add a sweet (optional) meme](giphy-url.gif)

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

