### PR TITLE
Add Chinese Translation for blog posts by 2024 Sep

### DIFF
--- a/site/_posts/zh-CN/2023-10-29-polyglot-1.7.0.md
+++ b/site/_posts/zh-CN/2023-10-29-polyglot-1.7.0.md
@@ -1,0 +1,31 @@
+---
+layout: post
+title: Polyglot 1.7.0 以及使用 page_id 前置元数据区分不同语言的永久链接
+lang: zh-CN
+---
+
+我很兴奋地宣布 Jekyll-Polyglot 1.7.0 版本发布了。这个版本增加了一个新功能，可以为页面设置特定于语言的永久链接，并保留它们与其他相关页面的关联。
+
+这项新功能由 **[antoniovazquezblanco](https://github.com/antoniovazquezblanco)** 提供，他是一位绅士和学者。
+
+## 使用 `page_id` 前置元数据将页面与不同永久链接关联
+
+Polyglot 通过匹配永久链接或文件名来关联页面。然而，有些站点翻译可能希望页面具有独特的永久链接。
+
+Polyglot 已经协调了不同语言的同一文档的多个副本。因此，基于 `page_id` 这样的新属性来协调相似页面，与基于永久链接协调没有任何区别。
+
+使用 `page_id` 来协调具有不同永久链接的相似页面，确保了自定义永久链接仍然可以在特定语言的站点上看到。
+
+### 为独特永久链接设置重定向
+
+独特永久链接的挑战在于相对化地生成的 URL。Polyglot 通过建议使用一致的永久链接完全避免了这个问题。
+
+为了解决这个问题，Polyglot 在这些页面上设置了 `redirect_from` 隐藏前置元数据，列出了相应页面的唯一永久链接。
+
+在使用 `jekyll-redirect-from` 插件时，将会读取这些前置元数据，并智能地将页面重定向到自定义的独特永久链接。
+
+要查看此功能的实际效果，请访问[这个不同语言的长永久链接的页面](/a-really-long/permalink/)。
+
+## 其他 bug 修复
+
+* 本次发布应该修复了 [#151](https://github.com/untra/polyglot/issues/151) 和 [#184](https://github.com/untra/polyglot/issues/184)，防止在调用其他 jekyll 命令时启动时崩溃。

--- a/site/_posts/zh-CN/2024-02-29-localized-variables.md
+++ b/site/_posts/zh-CN/2024-02-29-localized-variables.md
@@ -1,0 +1,95 @@
+---
+layout: post
+title: 本地化变量
+lang: zh-CN
+---
+
+Polyglot 允许您在 Jekyll 站点中为不同语言拥有不同的页面。例如，一个人可以在英语中有一个 `about.md` 页面，在西班牙语中有另一个 `about.md` 页面，它们具有完全不同的布局。但是，如果您希望为这两个页面使用相同的布局，您可以使用本地化变量。这是一种在 Jekyll 站点中为不同语言拥有不同数据的方法，但对所有语言使用相同的布局。
+
+下面我将使用一个使用 Polyglot 创建的[模板站点](https://github.com/george-gca/multi-language-al-folio) 作为示例。
+
+## 在页面之间共享布局
+
+在这个网站中，他们为每种语言的每个页面都有一个关于页面。其中，英语版本在 [\_pages/en-us/about.md](https://github.com/george-gca/multi-language-al-folio/blob/main/_pages/en-us/about.md)，而巴西葡萄牙语版本在 [\_pages/pt-br/about.md](https://github.com/george-gca/multi-language-al-folio/blob/main/_pages/pt-br/about.md) 中。在这两个页面中，我们可以看到它们的前置元数据中有相同的键，但有些值不同。这两个文件都指向相同的[布局](https://jekyllrb.com/docs/layouts/)：[关于](https://github.com/george-gca/multi-language-al-folio/blob/main/_layouts/about.liquid)页面模板，并且此页面模板使用前置元数据中的值来渲染页面。
+
+例如，英语页面的 `subtitle` 键的值为 `subtitle: <a href='#'>Affiliations</a>. Address. Contacts. Moto. Etc.`，而巴西葡萄牙语页面的值为 `subtitle: <a href='#'>Afiliações</a>. Endereço. Contatos. Lema. Etc.`。要在布局中使用此信息，可以这样使用：
+
+{% raw %}
+```liquid
+{{ page.subtitle }}
+```
+{% endraw %}
+
+这两个文件中前置元数据下方的内容也是一样的，可以在布局中这样使用：
+
+{% raw %}
+```liquid
+{{ content }}
+```
+{% endraw %}
+
+Polyglot 会自动使用当前语言的正确值渲染页面。
+
+## 在页面之间共享布局和本地化数据
+
+对于页面的 `subtitle`，他们在前置元数据中使用了 `key: value` 键值对，但有时我们希望在站点的不同部分中使用这些相同的对。例如，如果我们想在 `about.md` 和另一个页面中使用相同的 `subtitle`，我们将不得不在这两个页面的前置元数据中重复相同的对。这并不是我们想要的，因为如果我们需要更改 `subtitle`，我们将不得不在两个地方更改它。这就是本地化数据的用武之地。您可以创建一个文件，例如 `_data/:lang/strings.yml`，每种语言一个，Polyglot 将这些键带到 `site.data[:lang].strings` 下。
+
+比如说，在模板站点中有两个文件，[\_data/en-us/strings.yml](https://github.com/george-gca/multi-language-al-folio/blob/main/_data/en-us/strings.yml) 和 [\_data/pt-br/strings.yml](https://github.com/george-gca/multi-language-al-folio/blob/main/_data/pt-br/strings.yml)。在第一个文件中，前置元数据内容包括：
+
+```yaml
+latest_posts: latest posts
+```
+
+而在第二个文件中，前置元数据内容包括：
+
+```yaml
+latest_posts: últimas postagens
+```
+
+这样，他们可以在布局中使用 `latest_posts` 键，如下所示：
+
+{% raw %}
+```liquid
+{{ site.data[site.active_lang].strings.latest_posts }}
+```
+{% endraw %}
+
+这样一来，`latest_posts` 变量的值将正确获取到当前语言的 `_data/:lang/strings.yml` 文件中定义的值。
+
+## 在前置元数据中定义要使用的变量
+
+现在，如果您想在页面的前置元数据中定义这个变量，这就有点棘手了。一个可能的解决方案是检查变量的值中是否有 `.`，如果有，就使用文件 `_data/:lang/strings.yml` 中的值。你可以这么进行操作：
+
+{% raw %}
+```liquid
+{% if frontmatter_var contains '.' %}
+  {% assign first_part = frontmatter_var | split: '.' | first %}
+  {% assign last_part = frontmatter_var | split: '.' | last %}
+  {% capture result %}{{ site.data[site.active_lang].strings[first_part][last_part] }}{% endcapture %}
+{% endif %}
+
+{{ result }}
+```
+{% endraw %}
+
+如果 `frontmatter_var = blog.title` ，这段代码就会生效。
+This will work, for example, if `frontmatter_var = blog.title`.
+
+现在，如果您需要在使用它之前检查本地化字符串（该案例情况下是 `blog.title`）是否实际存在于文件 `_data/:lang/strings.yml` 中，您将不得不创建一个插件来检查变量是否存在于文件 `_data/:lang/strings.yml` 中，如果存在，则使用它，否则回退到任何您想要的值。我不会详细介绍如何做到这一点，但我会向您展示如何使用它。您可以在[这里](https://github.com/george-gca/multi-language-al-folio/blob/main/_plugins/localization-exists.rb)参阅该插件的代码。
+
+{% raw %}
+```liquid
+{% if frontmatter_var contains '.' %}
+  {% capture contains_localization %}{% localization_exists {{ frontmatter_var }} %}{% endcapture %}
+  {% if contains_localization == 'true' %}
+    {% assign first_part = frontmatter_var | split: '.' | first %}
+    {% assign last_part = frontmatter_var | split: '.' | last %}
+    {% capture result %}{{ site.data[site.active_lang].strings[first_part][last_part] }}{% endcapture %}
+  {% else %}
+    {% capture result %}fallback value{% endcapture %}
+  {% endif %}
+{% endif %}
+
+{{ result }}
+```
+{% endraw %}

--- a/site/_posts/zh-CN/2024-03-17-polyglot-1.8.0.md
+++ b/site/_posts/zh-CN/2024-03-17-polyglot-1.8.0.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: Polyglot 1.8.0 - 社区贡献发布
+lang: zh-CN
+---
+
+非常兴奋地宣布 Jekyll-Polyglot 1.8.0 版本发布了，这个版本增加了一些功能改进，并认可了来自社区的文档和贡献！
+
+## 不同语言的专属永久链接
+
+Polyglot 1.8.0 版本增加了一些新功能，可以为页面设置特定于语言的永久链接，并保留它们与其他相关页面的关联。这个新功能由一位绅士和学者—— **[antoniovazquezblanco](https://github.com/antoniovazquezblanco)** 提供。
+
+## 网站地图生成和 i18n SEO
+
+这个版本还认可了 **[jerturowetz](https://github.com/jerturowetz)** 提供的高质量 [sitemap.xml]({{ site.url }}/sitemap.xml) 和 [robots.txt]({{ site.url }}/robots.txt) 解决方案。本网站现在通过这些文件更好地展示和捕获了搜索引擎提供的 SEO 力量。可以在[这里](https://github.com/untra/polyglot/tree/master/site)查看示例网站的文件。
+
+## jekyll :polyglot :post_write 钩子
+
+GitHub 用户 **[obfusk](https://github.com/obfusk)** 在几年前贡献了一个[微小的 PR](https://github.com/untra/polyglot/pull/142)：
+
+通过多语言 `:site, :post_write` 钩子，像这样为每个子进程运行：
+
+```rb
+Jekyll::Hooks.register :site, :post_write do |site|
+  ...
+end
+```
+
+这个版本增加了一个自定义 `:post_write` 钩子，它在所有语言处理完成后运行一次（无论是否使用 `parallel_localization`）：
+
+```rb
+Jekyll::Hooks.register :polyglot, :post_write do |site|
+  # do something amazing here!
+end
+```
+
+这一特性对于使用了 [Jekyll hook 插件](https://jekyllrb.com/docs/plugins/hooks/)的复杂的 Jekyll 静态站点非常有用。
+
+她还为[语言子进程崩溃时的额外日志记录](https://github.com/untra/polyglot/pull/145)提供了修复。感谢这个贡献！
+
+## 本地化变量和葡萄牙语翻译
+
+**[george-gca](https://github.com/george-gca)** 是一个才华横溢的、很棒的家伙，他为如何最好地从站点数据本地化富文本贡献了[一整篇博客文章](/2024/02/29/localized-variables/)。他还提供了[本站的葡萄牙语翻译](https://polyglot.untra.io/pt-BR/)。

--- a/site/_posts/zh-CN/2024-08-18-polyglot-1.8.1.md
+++ b/site/_posts/zh-CN/2024-08-18-polyglot-1.8.1.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Polyglot 1.8.1 - Community Bug Fixes Release
+title: Polyglot 1.8.1 - 社区 Bug 修复发布
 lang: zh-CN
 ---
 
-Jekyll-Polyglot 1.8.1 版本已经发布，其中包含了一些功能改进，并修复了社区发现的漏洞。
+Jekyll-Polyglot 1.8.1 版本已经发布，其中包含了一些功能改进，并修复了社区发现的 Bug。
 
-## 社区贡献的漏洞修复
+## 社区提供的 Bug 修复
 
-**[hacketiwack](https://github.com/hacketiwack)** 提供了用于 [更严格检查设置文档永久链接](https://github.com/untra/polyglot/pull/200/files) 的代码，防止因空的前置字段导致的下游问题。
+**[hacketiwack](https://github.com/hacketiwack)** 提供了用于[更严格检查设置文档永久链接](https://github.com/untra/polyglot/pull/200/files)的代码，防止因空的前置字段导致的下游问题。
 
-Github 用户 **[blackpill](https://github.com/blackpill)**  提交了针对 i18n headers 标签的 [单字符错误修复](https://github.com/untra/polyglot/pull/211/files)，用于渲染默认语言链接的替代链接（href）。
+Github 用户 **[blackpill](https://github.com/blackpill)** 提交了针对 i18n headers 标签的[单字符错误修复](https://github.com/untra/polyglot/pull/211/files)，用于渲染默认语言链接的替代链接（href）。

--- a/site/complex-permalink.zh-CN.md
+++ b/site/complex-permalink.zh-CN.md
@@ -1,13 +1,13 @@
 ---
 layout: page
 title: 一条超长的永久链接
-permalink: a-really-long-chinese/permalink/
+permalink: yi-tiao-chao-chang-de-yong-jiu-lian-jie/permalink/
 lang: zh-CN
 page_id: complex-permalink
 ---
 
 这个永久链接真的超长超复杂
 
-该页面通过“page_id”与每种支持的语言的副本相对化和协调。
+该页面通过 `page_id` 实现了相对化生成 URL 和协调，以便为每种支持的语言提供副本。
 
-If you use `jekyll-redirect-from` and a customized [redirect.html layout](https://github.com/untra/polyglot/blob/master/site/_layouts/redirect.html), this permalink will be redirected when viewed from different languages.
+如果您使用 `jekyll-redirect-from` 并且自定义了 [redirect.html 布局](https://github.com/untra/polyglot/blob/master/site/_layouts/redirect.html)，这个永久链接将在不同语言下查看时被重定向。


### PR DESCRIPTION
## 🔤 Polyglot PR

> Description here

I decided to set up my bilingual technical blog again so I just recollected that we had such a great plugin...

I have translated the website post into Chinese since I last did it. Once per year. You are welcome ;)

And I think [my blog](https://aturret.space/) is a good example of using Polyglot with the most popular Jekyll personal technical writing blog theme, [Chirpy](https://github.com/cotes2020/jekyll-theme-chirpy). Could you please consider adding it to the sample site part of `README.md` ? I hope that my solution can help people who want to build a multilingual site with Chirpy theme. 

<!-- thanks for making a pull request! you are a handsome and kind individual, and you should be proud of your accomplishments -->

![add a sweet (optional) meme](giphy-url.gif)

## Type of change

- [x] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [ ] If modifying code, at least one test has been added to the suite
