### PR TITLE
Update `derive_lang_from_path` to derive from any part of path

### DIFF
--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -114,15 +114,14 @@ module Jekyll
       end
 
       segments = doc.relative_path.split('/')
-      if doc.relative_path[0] == '_' \
-        && segments.length > 2 \
-        && segments[1] =~ /^[a-z]{2,3}(:?[_-](:?[A-Za-z]{2}){1,2}){0,2}$/
-        return segments[1]
-      elsif segments.length > 1 \
-        && segments[0] =~ /^[a-z]{2,3}(:?[_-](:?[A-Za-z]{2}){1,2}){0,2}$/
-        return segments[0]
-      end
 
+      # loop through all segments and check if they match the language regex
+      segments.each do |segment|
+        if segment =~ /^[a-z]{2,3}(:?[_-](:?[A-Za-z]{2}){1,2}){0,2}$/
+          return segment
+        end
+      end
+      
       nil
     end
 

--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -117,7 +117,7 @@ module Jekyll
 
       # loop through all segments and check if they match the language regex
       segments.each do |segment|
-        if segment =~ /^[a-z]{2,3}(:?[_-](:?[A-Za-z]{2}){1,2}){0,2}$/
+        if @languages.include?(segment)
           return segment
         end
       end


### PR DESCRIPTION
## 🔤 Polyglot PR

Currently `derive_lang_from_path` only considers small parts of the path. This changes to consider any part in `any/part/of/the/path.txt`. This allows, for example, creating files like `assets/data/en-us/cards.json` and `assets/data/pt-br/cards.json` and setting its permalink to `/assets/data/cards.json`.

I need help setting tests for this, I have no idea where to start.

![typing as crazy](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWlxaHlrOWl6c3k3YWJoYnU5NHp2dGU1NTJqa3JjODFhYzNmazBzYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fQZX2aoRC1Tqw/giphy.gif)

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [ ] If modifying code, at least one test has been added to the suite
