### PR TITLE
Update README.md with instructions to require a url

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ languages: ["en", "sv", "de", "fr"]
 default_lang: "en"
 exclude_from_localization: ["javascript", "images", "css", "public"]
 parallel_localization: true
+url: https://polyglot.untra.io
 ```
 These configuration preferences indicate
 - what i18n languages you wish to support
 - what is your default "fallback" language for your content
-- what root level files/folders are excluded from localization, based
-  on if their paths start with any of the excluded regexp substrings. (this is different from the jekyll `exclude: [ .gitignore ]` ; you should `exclude` files and directories in your repo you dont want in your built site at all, and `exclude_from_localization` files and directories you want to see in your built site, but not in your sublanguage sites.)
-- whether to run language processing in parallel or serial
+- what root level files/folders are excluded from localization, based on if their paths start with any of the excluded regexp substrings. (this is different from the jekyll `exclude: [ .gitignore ]` ; you should `exclude` files and directories in your repo you dont want in your built site at all, and `exclude_from_localization` files and directories you want to see in your built site, but not in your sublanguage sites.)
+- whether to run language processing in parallel or serial. Set to `false` if building on Windows hosts, or if Polyglot collides with other Jekyll plugins.
+- your jekyll website production url. Make sure this value is set; Polyglot requires this to relative site urls correctly, and to make functioning language switchers.
 
 The optional `lang_from_path: true` option enables getting page
 language from the first or second path segment, e.g `de/first-one.md`, or


### PR DESCRIPTION
## 🔤 Polyglot PR

Once again a big thanks to @george-gca for identifying that language switchers struggle to work when the site url is not defined in #225 . Adding additional information to the README to prevent this pitfall for others, that I think has bitten other jekyll users before.

<!-- thanks for making a pull request! you are a handsome and kind individual, and you should be proud of your accomplishments -->

![add a sweet (optional) meme](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExamI2OTJpNngzNXRjd3k4ZGd4dDZoNWc2bjNvdHMyd3hqNXppbm8yNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1IFYQTsv9VyoYOcsAF/giphy-downsized.gif)

## Type of change

- [x] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [ ] If modifying code, at least one test has been added to the suite
