### PR TITLE
Smarter page redirects, `all_langs` assignment, codecoverage, ruby >= 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 jobs:
   build: # our first job, named "build"
     docker:
-      - image: cimg/ruby:2.7 # use a tailored CircleCI docker image.
+      - image: cimg/ruby:3.1 # use a tailored CircleCI docker image.
     steps:
       - checkout # pull down our git code.
       - ruby/install-deps # use the ruby orb to install dependencies
@@ -19,7 +19,7 @@ jobs:
   test:  # our next job, called "test"
     # here we set TWO docker images.
     docker:
-      - image: cimg/ruby:2.7 # this is our primary docker image, where step commands run.
+      - image: cimg/ruby:3.1 # this is our primary docker image, where step commands run.
     environment:
       CI: "true"
       CODECOV_TOKEN: ${CODECOV_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 # Use a package of configuration called an orb.
 orbs:
   ruby: circleci/ruby@1.0
+  codecov: codecov/codecov@5
 
 jobs:
   build: # our first job, named "build"
@@ -11,25 +12,30 @@ jobs:
     steps:
       - checkout # pull down our git code.
       - ruby/install-deps # use the ruby orb to install dependencies
+      - run:
+          name: Make test.sh executable
+          command: chmod +x test.sh
+
   test:  # our next job, called "test"
     # here we set TWO docker images.
     docker:
       - image: cimg/ruby:2.7 # this is our primary docker image, where step commands run.
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+    environment:
+      CI: "true"
+      CODECOV_TOKEN: ${CODECOV_TOKEN}
     # A series of steps to run, some are similar to those in "build".
     steps:
       - checkout 
       - ruby/install-deps 
-      # Run rspec in parallel
-      - ruby/rspec-test
       - run:
-          name: Run unit tests using Rails
-          command: |
-            RAILS_ENV=test bundle exec rake
+          name: Run tests and upload coverage
+          command: ./test.sh
+      - codecov/upload
       - store_test_results:
-          path: test/reports
+          path: rspec.xml
+      - store_artifacts:
+          path: coverage/.last_run.json
+          destination: coverage-report.json
 
 # We use workflows to orchestrate the jobs that we declared above.
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,48 +1,61 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
-# Use a package of configuration called an orb.
 orbs:
   ruby: circleci/ruby@1.0
-  codecov: codecov/codecov@5
+  codecov: codecov/codecov@5.3.0
 
 jobs:
-  build: # our first job, named "build"
+  build:
     docker:
-      - image: cimg/ruby:3.1 # use a tailored CircleCI docker image.
+      - image: cimg/ruby:3.1
     steps:
-      - checkout # pull down our git code.
-      - ruby/install-deps # use the ruby orb to install dependencies
+      - checkout 
+      - ruby/install-deps
       - run:
           name: Make test.sh executable
           command: chmod +x test.sh
 
-  test:  # our next job, called "test"
-    # here we set TWO docker images.
+  test:
     docker:
-      - image: cimg/ruby:3.1 # this is our primary docker image, where step commands run.
+      - image: cimg/ruby:3.1
     environment:
       CI: "true"
       CODECOV_TOKEN: ${CODECOV_TOKEN}
-    # A series of steps to run, some are similar to those in "build".
     steps:
       - checkout 
       - ruby/install-deps 
       - run:
           name: Run tests and upload coverage
           command: ./test.sh
-      - codecov/upload
       - store_test_results:
           path: rspec.xml
       - store_artifacts:
-          path: coverage/.last_run.json
+          path: coverage
+          destination: coverage
+      - store_artifacts:
+          path: coverage/coverage.json
           destination: coverage-report.json
+      - store_artifacts:
+          path: coverage/.last_run.json
+          destination: last-run-report.json
 
-# We use workflows to orchestrate the jobs that we declared above.
+  codecov-upload:
+    docker:
+      - image: cimg/ruby:3.1
+    steps:
+      - checkout
+      - codecov/upload:
+          files: coverage/coverage.json,coverage/.last_run.json
+          disable_search: true
+          fail_on_error: true
+
 workflows:
   version: 2
-  build_and_test:     # The name of our workflow is "build_and_test"
-    jobs:             # The list of jobs we run as part of this workflow.
-      - build         # Run build first.
-      - test:         # Then run test,
-          requires:   # Test requires that build passes for it to run.
-            - build   # Finally, run the build job.
+  build_and_test:     
+    jobs:           
+      - build        
+      - test:      
+          requires:  
+            - build
+      - codecov-upload:
+          requires:
+            - test

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ _site/**
 vendor/bundle
 
 # test output
+coverage/*
+rspec.json
 rspec.xml
 
 # NOTE: this will need to be ungitignored to run publish

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,18 @@
+require:
+  - rubocop-rspec
+
 AllCops:
+  NewCops: enable
+  TargetRubyVersion: 2.7
   Exclude:
     - 'bin/**/*'
     - 'db/**/*'
     - 'config/**/*'
     - 'script/**/*'
+    - 'vendor/**/*'  # Exclude vendor directory to avoid conflicts with Jekyll's RuboCop config
+  SuggestExtensions: false
 
+# Layout
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
@@ -26,17 +34,21 @@ Layout/SpaceInsideHashLiteralBraces:
 Layout/HashAlignment:
   Enabled: true
   EnforcedLastArgumentHashStyle: always_ignore
-  
+
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
+Layout/LineLength:
+  Enabled: false
+
+# Style
 Style/AsciiComments:
   Enabled: false
 
 Style/CollectionMethods:
   Enabled: true
   PreferredMethods:
-      inject: 'inject'
+    inject: 'inject'
 
 Style/Documentation:
   Enabled: false
@@ -60,27 +72,6 @@ Style/RaiseArgs:
 Style/SignalException:
   Enabled: false
 
-Metrics/PerceivedComplexity:
-  Max: 15
-
-Metrics/CyclomaticComplexity:
-  Max: 15
-
-Metrics/AbcSize:
-  Max: 20
-
-Metrics/ClassLength:
-  Max: 200
-
-Metrics/ModuleLength:
-  Max: 200
-
-Metrics/LineLength:
-  Enabled: false
-
-Metrics/MethodLength:
-  Max: 30
-
 Style/SingleLineBlockParams:
   Enabled: false
 
@@ -96,8 +87,132 @@ Style/RedundantSelf:
 Style/TrivialAccessors:
   AllowPredicates: true
 
-Lint/RedundantReturn:
+Style/RedundantReturn:
   Description: 'Do not use return in an ensure block.'
   StyleGuide: '#no-return-ensure'
   Enabled: true
-  VersionAdded: '0.9'
+
+# Metrics
+Metrics/PerceivedComplexity:
+  Max: 20
+
+Metrics/CyclomaticComplexity:
+  Max: 20
+
+Metrics/AbcSize:
+  Max: 50
+
+Metrics/ClassLength:
+  Max: 300
+
+Metrics/ModuleLength:
+  Max: 200
+
+Metrics/MethodLength:
+  Max: 50
+
+# RSpec
+RSpec/ExampleLength:
+  Max: 100
+
+RSpec/MultipleExpectations:
+  Max: 10
+
+RSpec/NestedGroups:
+  Max: 4
+
+RSpec/DescribeClass:
+  Enabled: false
+
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+
+# Disable obnoxious RSpec rules
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/ExampleWording:
+  Enabled: false
+
+RSpec/EmptyLineAfterExample:
+  Enabled: false
+
+RSpec/BeEq:
+  Enabled: false
+
+RSpec/NotToNot:
+  Enabled: false
+
+RSpec/RepeatedExample:
+  Enabled: false
+
+RSpec/RepeatedDescription:
+  Enabled: false
+
+RSpec/HookArgument:
+  Enabled: false
+
+RSpec/DescribedClass:
+  Enabled: false
+
+RSpec/EmptyLineAfterHook:
+  Enabled: false
+
+# Disable other obnoxious rules
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/ExpandPathArguments:
+  Enabled: false
+
+Style/MixinUsage:
+  Enabled: false
+
+Style/BlockComments:
+  Enabled: false
+
+Style/MagicCommentFormat:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
+Style/RedundantLineContinuation:
+  Enabled: false
+
+Style/HashSyntax:
+  Enabled: false
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Style/Semicolon:
+  Enabled: false
+
+Style/OrAssignment:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/RedundantCapitalW:
+  Enabled: false
+
+Layout/ArgumentAlignment:
+  Enabled: false
+
+Layout/EmptyComment:
+  Enabled: false
+
+# Disable naming rules
+Naming/VariableName:
+  Enabled: false
+
+Naming/FileName:
+  Enabled: false
+
+Naming/MethodName:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   Exclude:
     - 'bin/**/*'
     - 'db/**/*'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,5 +9,6 @@ If you make any contributions to ruby source code, I will request you add a test
 
 In the spec/ directory there are a series of ruby spec files.
 
-run tests with `bundle exec rspec --format RspecJunitFormatter`
+run tests with `test.sh`.
+rebuild the gem and example site with `make.sh`.
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ group :test do
   gem 'rspec_junit_formatter', '>= 0.6.0'
   gem 'rspec-mocks', '>= 3.11.0'
   gem 'rubocop', '>= 1.66.0'
+  gem 'rubocop-performance', '>= 1.19.0'
+  gem 'rubocop-rspec', '>= 2.19.0'
 end
 
 gem 'jekyll'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :test do
   gem 'rubocop', '>= 1.66.0'
   gem 'rubocop-performance', '>= 1.19.0'
   gem 'rubocop-rspec', '>= 2.19.0'
+  gem 'simplecov', '>= 0.22.0'
 end
 
 gem 'jekyll'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ gemspec
 
 gem 'rake'
 group :test do
+  gem 'codecov', '~> 0.6.0'
   gem 'minitest', '>= 5.16.3'
   gem 'nokogiri', '>= 1.14.3'
   gem 'rspec', '>= 3.11.0'
@@ -11,7 +12,8 @@ group :test do
   gem 'rubocop', '>= 1.66.0'
   gem 'rubocop-performance', '>= 1.19.0'
   gem 'rubocop-rspec', '>= 2.19.0'
-  gem 'simplecov', '>= 0.22.0'
+  gem 'simplecov', '~> 0.21.2'
+  gem 'simplecov-json', '>= 0.2.1'
 end
 
 gem 'jekyll'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,11 @@ GEM
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.37.0)
       parser (>= 3.3.1.0)
+    rubocop-performance (1.23.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rspec (3.4.0)
+      rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     safe_yaml (1.0.5)
     sass-embedded (1.77.4)
@@ -151,6 +156,8 @@ DEPENDENCIES
   rspec-mocks (>= 3.11.0)
   rspec_junit_formatter (>= 0.6.0)
   rubocop (>= 1.66.0)
+  rubocop-performance (>= 1.19.0)
+  rubocop-rspec (>= 2.19.0)
   webrick (>= 1.8.2)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
     colorator (1.1.0)
     concurrent-ruby (1.3.3)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -134,6 +135,12 @@ GEM
       google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.77.4-x86_64-darwin)
       google-protobuf (>= 3.25, < 5.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.5.0)
@@ -158,6 +165,7 @@ DEPENDENCIES
   rubocop (>= 1.66.0)
   rubocop-performance (>= 1.19.0)
   rubocop-rspec (>= 2.19.0)
+  simplecov (>= 0.22.0)
   webrick (>= 1.8.2)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,8 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     bigdecimal (3.1.8)
+    codecov (0.6.0)
+      simplecov (>= 0.15, < 0.22)
     colorator (1.1.0)
     concurrent-ruby (1.3.3)
     diff-lcs (1.5.1)
@@ -135,11 +137,14 @@ GEM
       google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.77.4-x86_64-darwin)
       google-protobuf (>= 3.25, < 5.0)
-    simplecov (0.22.0)
+    simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
+    simplecov-json (0.2.3)
+      json
+      simplecov
     simplecov_json_formatter (0.1.4)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -152,6 +157,7 @@ PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
+  codecov (~> 0.6.0)
   jekyll
   jekyll-paginate
   jekyll-polyglot!
@@ -165,7 +171,8 @@ DEPENDENCIES
   rubocop (>= 1.66.0)
   rubocop-performance (>= 1.19.0)
   rubocop-rspec (>= 2.19.0)
-  simplecov (>= 0.22.0)
+  simplecov (~> 0.21.2)
+  simplecov-json (>= 0.2.1)
   webrick (>= 1.8.2)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ---
 [![Gem Version](https://badge.fury.io/rb/jekyll-polyglot.svg)](https://badge.fury.io/rb/jekyll-polyglot)
 [![CircleCI](https://circleci.com/gh/untra/polyglot/tree/master.svg?style=svg)](https://circleci.com/gh/untra/polyglot/?branch=master)
+[![codecov](https://codecov.io/gh/untra/polyglot/graph/badge.svg?token=AAIYBIxdWr)](https://codecov.io/gh/untra/polyglot)
 
 __Polyglot__ is a fast, painless, open-source internationalization plugin for [Jekyll](http://jekyllrb.com) blogs. Polyglot is easy to set up and use with any Jekyll project, and it scales to the languages you want to support. With fallback support for missing content, automatic url relativization, and powerful SEO tools, Polyglot allows any multi-language jekyll blog to focus on content without the cruft.
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Polyglot will only start builds after it confirms there is a cpu core ready to a
 ### Writing Tests and Debugging
 _:wave: I need assistance with modern ruby best practices for test maintenance with rake and rspec. If you got the advice I have the ears._
 
-Tests are run with `bundle exec rake`. Tests are in the `/spec` directory, and test failure output detail can be examined in the `rspec.xml` file.
+Tests are run with `test.sh`. Tests are in the `/spec` directory, and test failure output detail can be examined in the `rspec.json` file. Code Coverage details are in the the `coverage` directory.
 
 ## Features
 This plugin stands out from other I18n Jekyll plugins.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,38 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+
+ignore:
+  - "spec/**/*"
+  - "test/**/*"
+  - "vendor/**/*"
+  - "bin/**/*"
+  - "lib/jekyll/polyglot/version.rb"
+
+fixes:
+  - "lib/::lib/"
+  - "spec/::spec/"
+
+parsers:
+  rubocop:
+    enable: true
+    file: "coverage/.last_run.json"
+    coverage:
+      status:
+        project:
+          default:
+            target: 80%
+            threshold: 1%
+        patch:
+          default:
+            target: 80%
+            threshold: 1% 

--- a/codecov.yml
+++ b/codecov.yml
@@ -21,18 +21,3 @@ ignore:
 fixes:
   - "lib/::lib/"
   - "spec/::spec/"
-
-parsers:
-  rubocop:
-    enable: true
-    file: "coverage/.last_run.json"
-    coverage:
-      status:
-        project:
-          default:
-            target: 80%
-            threshold: 1%
-        patch:
-          default:
-            target: 80%
-            threshold: 1% 

--- a/jekyll-polyglot.gemspec
+++ b/jekyll-polyglot.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://polyglot.untra.io/'
   s.license     = 'MIT'
   s.add_dependency('jekyll', '>= 3.0', '>= 4.0')
-  s.required_ruby_version     = '>= 2.7.0'
-  s.required_rubygems_version = '>= 2.7.0'
+  s.required_ruby_version     = '>= 3.1.0'
+  s.required_rubygems_version = '>= 3.1.0'
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/jekyll-polyglot.gemspec
+++ b/jekyll-polyglot.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'jekyll-polyglot'
   s.version     = '1.9.0'
-  s.date        = '2025-01-18'
   s.summary     = 'I18n plugin for Jekyll Blogs'
   s.description = 'Fast open source i18n plugin for Jekyll blogs.'
   s.authors     = ['Samuel Volin']
@@ -9,7 +8,8 @@ Gem::Specification.new do |s|
   s.files       = ['README.md', 'LICENSE'] + Dir['lib/**/*']
   s.homepage    = 'https://polyglot.untra.io/'
   s.license     = 'MIT'
-  s.add_runtime_dependency('jekyll', '>= 3.0', '>= 4.0')
+  s.add_dependency('jekyll', '>= 3.0', '>= 4.0')
   s.required_ruby_version     = '>= 2.7.0'
   s.required_rubygems_version = '>= 2.7.0'
+  s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/jekyll/polyglot/hooks/coordinate.rb
+++ b/lib/jekyll/polyglot/hooks/coordinate.rb
@@ -8,7 +8,7 @@ def hook_coordinate(site)
   # Copy the language specific data, by recursively merging it with the default data.
   # Favour active_lang first, then default_lang, then any non-language-specific data.
   # See: https://www.ruby-forum.com/topic/142809
-  merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+  merger = proc { |_key, v1, v2| v1.is_a?(Hash) && v2.is_a?(Hash) ? v1.merge(v2, &merger) : v2 }
   if site.data.include?(site.default_lang)
     site.data = site.data.merge(site.data[site.default_lang], &merger)
   end
@@ -16,7 +16,7 @@ def hook_coordinate(site)
     site.data = site.data.merge(site.data[site.active_lang], &merger)
   end
 
-  site.collections.each do |_, collection|
+  site.collections.each_value do |collection|
     collection.docs = site.coordinate_documents(collection.docs)
   end
   site.pages = site.coordinate_documents(site.pages)

--- a/lib/jekyll/polyglot/hooks/process.rb
+++ b/lib/jekyll/polyglot/hooks/process.rb
@@ -4,7 +4,7 @@ Jekyll::Hooks.register :site, :post_render do |site|
 end
 
 def hook_process(site)
-  site.collections.each do |_, collection|
+  site.collections.each_value do |collection|
     site.process_documents(collection.docs)
   end
   site.process_documents(site.pages)

--- a/lib/jekyll/polyglot/liquid/tags/i18n_headers.rb
+++ b/lib/jekyll/polyglot/liquid/tags/i18n_headers.rb
@@ -15,14 +15,14 @@ module Jekyll
           permalink_lang = context.registers[:page]['permalink_lang']
           site_url = @url.empty? ? site.config['url'] : @url
           i18n = "<meta http-equiv=\"Content-Language\" content=\"#{site.active_lang}\">\n"
-          i18n += "<link rel=\"alternate\" hreflang=\"#{site.default_lang}\" "\
-          "href=\"#{site_url}/#{permalink}\"/>\n"
+          i18n += "<link rel=\"alternate\" hreflang=\"#{site.default_lang}\" " \
+                  "href=\"#{site_url}/#{permalink}\"/>\n"
           site.languages.each do |lang|
             next if lang == site.default_lang
 
             url = permalink_lang && permalink_lang[lang] ? permalink_lang[lang] : permalink
-            i18n += "<link rel=\"alternate\" hreflang=\"#{lang}\" "\
-            "href=\"#{site_url}/#{lang}/#{url}\"/>\n"
+            i18n += "<link rel=\"alternate\" hreflang=\"#{lang}\" " \
+                    "href=\"#{site_url}/#{lang}/#{url}\"/>\n"
           end
           i18n
         end

--- a/lib/jekyll/polyglot/liquid/tags/static_href.rb
+++ b/lib/jekyll/polyglot/liquid/tags/static_href.rb
@@ -1,17 +1,13 @@
 module Jekyll
   module Polyglot
     module Liquid
-      class StaticHrefTag < :: Liquid::Block
-        def initialize(tag_name, params, tokens)
-          super
-        end
-
+      class StaticHrefTag < ::Liquid::Block
         def render(context)
           text = super
           href_attrs = text.strip.split '='
           valid = (href_attrs.length == 2 && href_attrs[0] == 'href') && href_attrs[1].start_with?('"') && href_attrs[1].end_with?('"')
           unless valid
-            raise Liquid::SyntaxError, "static_href parameters must include match href=\"...\" attribute param, eg. href=\"http://example.com\, href=\"/about\", href=\"/\" , instead got:\n#{text}"
+            raise Liquid::SyntaxError, "static_href parameters must include match href=\"...\" attribute param, eg. href=\"http://example.com, href=\"/about\", href=\"/\" , instead got:\n#{text}"
           end
 
           href_value = href_attrs[1]

--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -1,3 +1,4 @@
+require 'English'
 require 'etc'
 
 include Process
@@ -31,7 +32,7 @@ module Jekyll
     alias process_orig process
     def process
       prepare
-      all_langs = (@languages + [@default_lang]).uniq
+      all_langs = ([@default_lang] + @languages).uniq
       if @parallel_localization
         nproc = Etc.nprocessors
         pids = {}
@@ -46,7 +47,7 @@ module Jekyll
                 next unless waitpid pid, Process::WNOHANG
 
                 pids.delete lang
-                raise "Polyglot subprocess #{pid} (#{lang}) failed (#{$?.exitstatus})" unless $?.success?
+                raise "Polyglot subprocess #{pid} (#{lang}) failed (#{$CHILD_STATUS.exitstatus})" unless $CHILD_STATUS.success?
               end
             end
           end
@@ -125,15 +126,17 @@ module Jekyll
         if @languages.include?(segment)
           return segment
         end
-      end
 
       # loop through all segments and check if they match the language regex
+      # loop through all segments and check if they match the language regex
+      segments.each do |segment|
+        # loop through all segments and check if they match the language regex
       segments.each do |segment|
         if @languages.include?(segment)
           return segment
         end
       end
-      
+
       nil
     end
 
@@ -163,8 +166,10 @@ module Jekyll
         approved[page_id] = doc
         @file_langs[page_id] = lang
       end
-      approved.values.each { |doc| assignPageRedirects(doc, docs) }
-      approved.values.each { |doc| assignPageLanguagePermalinks(doc, docs) }
+      approved.each_value do |doc|
+        assignPageRedirects(doc, docs)
+        assignPageLanguagePermalinks(doc, docs)
+      end
       approved.values
     end
 
@@ -175,8 +180,21 @@ module Jekyll
         langPrefix = lang === @default_lang ? '' : "#{lang}/"
         redirectDocs = docs.select do |dd|
           doclang = dd.data['lang'] || derive_lang_from_path(dd) || @default_lang
-          dd.data['page_id'] == pageId && doclang != lang && dd.data['permalink'] != doc.data['permalink']
+          dd.data['page_id'] == pageId &&
+            doclang == lang &&
+            dd.data['permalink'] != doc.data['permalink']
         end
+
+        # If no language-specific redirects found, fallback
+        if redirectDocs.empty? && lang != @default_lang
+          redirectDocs = docs.select do |dd|
+            doclang = dd.data['lang'] || derive_lang_from_path(dd) || @default_lang
+            dd.data['page_id'] == pageId &&
+              doclang == @default_lang &&
+              dd.data['permalink'] != doc.data['permalink']
+          end
+        end
+
         redirects = redirectDocs.map { |dd| dd.data['permalink'] }
         doc.data['redirect_from'] = redirects
       end
@@ -221,7 +239,7 @@ module Jekyll
     def document_url_regex
       regex = ''
       (@languages || []).each do |lang|
-        regex += "([\/\.]#{lang}[\/\.])|"
+        regex += "([/.]#{lang}[/.])|"
       end
       regex.chomp! '|'
       /#{regex}/
@@ -238,7 +256,7 @@ module Jekyll
           regex += "(?!#{x})"
         end
         @languages.each do |x|
-          regex += "(?!#{x}\/)"
+          regex += "(?!#{x}/)"
         end
       end
       start = disabled ? 'ferh' : 'href'
@@ -256,7 +274,7 @@ module Jekyll
           regex += "(?!#{x})"
         end
         @languages.each do |x|
-          regex += "(?!#{x}\/)"
+          regex += "(?!#{x}/)"
         end
       end
       start = disabled ? 'ferh' : 'href'
@@ -267,7 +285,7 @@ module Jekyll
       return if doc.output.nil?
 
       modified_output = doc.output.dup
-      modified_output.gsub!(regex, "href=\"#{@baseurl}/#{@active_lang}/" + '\1"')
+      modified_output.gsub!(regex, "href=\"#{@baseurl}/#{@active_lang}/\\1\"")
       doc.output = modified_output
     end
 
@@ -275,7 +293,7 @@ module Jekyll
       return if doc.output.nil?
 
       modified_output = doc.output.dup
-      modified_output.gsub!(regex, "href=\"#{url}#{@baseurl}/#{@active_lang}/" + '\1"')
+      modified_output.gsub!(regex, "href=\"#{url}#{@baseurl}/#{@active_lang}/\\1\"")
       doc.output = modified_output
     end
 
@@ -283,7 +301,7 @@ module Jekyll
       return if doc.output.nil?
 
       modified_output = doc.output.dup
-      modified_output.gsub!(regex, "href=\"#{url}#{@baseurl}/" + '\1"')
+      modified_output.gsub!(regex, "href=\"#{url}#{@baseurl}/\\1\"")
       doc.output = modified_output
     end
 
@@ -291,7 +309,7 @@ module Jekyll
       return if doc.output.nil?
 
       modified_output = doc.output.dup
-      modified_output.gsub!(regex, "href=\"#{@baseurl}/" + '\1"')
+      modified_output.gsub!(regex, "href=\"#{@baseurl}/\\1\"")
       doc.output = modified_output
     end
   end

--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -43,10 +43,10 @@ module Jekyll
             end
             while pids.length >= (lang == all_langs[-1] ? 1 : nproc)
               sleep 0.1
-              pids.map do |lang, pid|
+              pids.map do |pid_lang, pid|
                 next unless waitpid pid, Process::WNOHANG
 
-                pids.delete lang
+                pids.delete pid_lang
                 raise "Polyglot subprocess #{pid} (#{lang}) failed (#{$CHILD_STATUS.exitstatus})" unless $CHILD_STATUS.success?
               end
             end
@@ -126,15 +126,6 @@ module Jekyll
         if @languages.include?(segment)
           return segment
         end
-
-      # loop through all segments and check if they match the language regex
-      # loop through all segments and check if they match the language regex
-      segments.each do |segment|
-        # loop through all segments and check if they match the language regex
-      segments.each do |segment|
-        if @languages.include?(segment)
-          return segment
-        end
       end
 
       nil
@@ -177,7 +168,6 @@ module Jekyll
       pageId = doc.data['page_id']
       if !pageId.nil? && !pageId.empty?
         lang = doc.data['lang'] || derive_lang_from_path(doc) || @default_lang
-        langPrefix = lang === @default_lang ? '' : "#{lang}/"
         redirectDocs = docs.select do |dd|
           doclang = dd.data['lang'] || derive_lang_from_path(dd) || @default_lang
           dd.data['page_id'] == pageId &&

--- a/lib/jekyll/polyglot/patches/jekyll/static_file.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/static_file.rb
@@ -1,19 +1,20 @@
-
 module Jekyll
   # Alteration to Jekyll StaticFile
   # provides aliased methods to direct write to skip files
   # excluded from localization
   class StaticFile
-    alias_method :write_orig, :write
+    alias write_orig write
     def write(dest)
       return false if exclude_from_localization?
+
       write_orig(dest)
     end
 
     def exclude_from_localization?
       return false if @site.active_lang == @site.default_lang
+
       @site.exclude_from_localization.each do |e|
-        return true if relative_path[1..-1].start_with?(e)
+        return true if relative_path[1..].start_with?(e)
       end
       false
     end

--- a/publi.sh
+++ b/publi.sh
@@ -4,3 +4,4 @@ rm -rf site/_site/
 cd site && bundle exec jekyll build && cd ..
 git add site/_site/ && git commit -m "$(date)"
 git subtree push --prefix site/_site origin gh-pages
+

--- a/spec/jekyll/polyglot/hooks/coordinate_spec.rb
+++ b/spec/jekyll/polyglot/hooks/coordinate_spec.rb
@@ -28,15 +28,14 @@ Dir.mktmpdir do |_|
       @site.prepare
       @collection = Jekyll::Collection.new(@site, "fixture")
       @site.data = { 'foo' => 'databar', 'baz' => 'databaz', 'strings' => {
-                       'banana' => 'banana',
-                     }, }
+                       'banana' => 'banana'
+                     } }
       @site.data['en'] = { 'foo' => 'enbar', 'strings' => {
-                             'apple' => 'apple', 'ice cream' => 'ice cream',
-                           }, }
+                             'apple' => 'apple', 'ice cream' => 'ice cream'
+                           } }
       @site.data['fr'] = { 'foo' => 'frbar', 'strings' => {
-                             'ice cream' => 'crème glacée',
-                           }, }
-      
+                             'ice cream' => 'crème glacée'
+                           } }
     end
 
     it 'should have trailing / on all dir entries in exclude_from_localization' do
@@ -81,46 +80,46 @@ Dir.mktmpdir do |_|
       it 'should include files in the default_lang without active_lang' do
         @site.process_language 'fr'
         expect(@site.pages).to have_attributes(size: 3)
-        expect(@site.pages.map { |doc| doc.name }).to include('en.about.md')
+        expect(@site.pages.map(&:name)).to include('en.about.md')
       end
 
       it 'should include files in the active_lang' do
         @site.process_language 'fr'
         expect(@site.pages).to have_attributes(size: 3)
-        expect(@site.pages.map { |doc| doc.name }).to include('fr.menu.md', 'fr.members.md')
+        expect(@site.pages.map(&:name)).to include('fr.menu.md', 'fr.members.md')
       end
 
       it 'should not include files in the default_lang with the active_lang' do
         @site.process_language 'fr'
-        print @site.pages.map { |doc| doc.name }
-        expect(@site.pages.map { |doc| doc.name }).not_to include('en.menu.md')
+        print(@site.pages.map(&:name))
+        expect(@site.pages.map(&:name)).not_to include('en.menu.md')
       end
 
       it 'should not include files in a different lang from the active_lang' do
         @site.process_language 'fr'
-        expect(@site.pages.map { |doc| doc.name }).not_to include('es.menu.md')
+        expect(@site.pages.map(&:name)).not_to include('es.menu.md')
       end
 
       it 'should not be included if the active_lang is not part of the lang-exclusive' do
         @site.process_language 'fr'
-        expect(@site.pages.map { |doc| doc.name }).not_to include('es.samba.md')
+        expect(@site.pages.map(&:name)).not_to include('es.samba.md')
       end
 
       it 'should respect permalinks when page_id is specified' do
         @site.process_language 'en'
-        expect(@site.pages.select { |doc| doc.name == 'en.about.md' }.first().permalink).to eq('about')
-        expect(@site.pages.select { |doc| doc.name == 'en.menu.md' }.first().permalink).to eq('the-menu')
+        expect(@site.pages.select { |doc| doc.name == 'en.about.md' }.first.permalink).to eq('about')
+        expect(@site.pages.select { |doc| doc.name == 'en.menu.md' }.first.permalink).to eq('the-menu')
         @site.process_language 'es'
-        expect(@site.pages.select { |doc| doc.name == 'es.menu.md' }.first().permalink).to eq('el-menu')
-        expect(@site.pages.select { |doc| doc.name == 'es.samba.md' }.first().permalink).to eq('samba')
+        expect(@site.pages.select { |doc| doc.name == 'es.menu.md' }.first.permalink).to eq('el-menu')
+        expect(@site.pages.select { |doc| doc.name == 'es.samba.md' }.first.permalink).to eq('samba')
         @site.process_language 'fr'
-        expect(@site.pages.select { |doc| doc.name == 'fr.menu.md' }.first().permalink).to eq('le-menu')
-        expect(@site.pages.select { |doc| doc.name == 'fr.members.md' }.first().permalink).to eq('members')
+        expect(@site.pages.select { |doc| doc.name == 'fr.menu.md' }.first.permalink).to eq('le-menu')
+        expect(@site.pages.select { |doc| doc.name == 'fr.members.md' }.first.permalink).to eq('members')
       end
-      
+
       it 'should contain permalink_lang when page_id is specified' do
         @site.process_language 'en'
-        menu_permalink_lang = @site.pages.select { |doc| doc.name == 'en.menu.md' }.first().data['permalink_lang']
+        menu_permalink_lang = @site.pages.select { |doc| doc.name == 'en.menu.md' }.first.data['permalink_lang']
         expect(menu_permalink_lang).to have_attributes(size: 3)
         expect(menu_permalink_lang.keys).to match_array(@site.config['languages'])
         expect(menu_permalink_lang['en']).to eq('the-menu')

--- a/spec/jekyll/polyglot/hooks/subprocess_spec.rb
+++ b/spec/jekyll/polyglot/hooks/subprocess_spec.rb
@@ -1,45 +1,42 @@
 require 'rspec/helper'
 describe 'site process error handling' do
-    before do
-      @config = Jekyll::Configuration::DEFAULTS.dup
-      @langs = ['en', 'fr', 'es']
-      @default_lang = 'en'
-      @exclude_from_localization = ['javascript', 'images', 'css/', 'README.md']
-      @config['langs'] = @langs
-      @config['default_lang'] = @default_lang
-      @config['exclude_from_localization'] = @exclude_from_localization
-      @parallel_localization = @config['parallel_localization'] || true
-      @site = Site.new(
-        Jekyll.configuration(
-          'languages'                 => @langs,
-          'default_lang'              => @default_lang,
-          'exclude_from_localization' => @exclude_from_localization,
-          'source'                    => File.expand_path('../../../../fixture', __FILE__)
-        )
+  before do
+    @config = Jekyll::Configuration::DEFAULTS.dup
+    @langs = ['en', 'fr', 'es']
+    @default_lang = 'en'
+    @exclude_from_localization = ['javascript', 'images', 'css/', 'README.md']
+    @config['langs'] = @langs
+    @config['default_lang'] = @default_lang
+    @config['exclude_from_localization'] = @exclude_from_localization
+    @parallel_localization = @config['parallel_localization'] || true
+    @site = Site.new(
+      Jekyll.configuration(
+        'languages'                 => @langs,
+        'default_lang'              => @default_lang,
+        'exclude_from_localization' => @exclude_from_localization,
+        'source'                    => File.expand_path('../../../../fixture', __FILE__)
       )
-      @site.prepare
-      @collection = Jekyll::Collection.new(@site, "fixture")
-      @site.data['en'] = { 'foo' => 'enbar', 'strings' => {
-                             'apple' => 'apple', 'ice cream' => 'ice cream',
-                           }, }
-      @site.data['fr'] = { 'foo' => 'frbar', 'strings' => {
-                             'ice cream' => 'crème glacée',
-                           }, }
-      
-    end
-    it "site.process throws FatalError if a subprocess fails" do
-      @thistestonly = false
-      semaphore = Mutex.new
-      Jekyll::Hooks.register(:site, :post_write) do |site|
-        
-          semaphore.synchronize {
-            unless @thistestonly
-              @thistestonly = true
-              raise 'fail fr intentionally'
-            end
-          }
-        
-      end
-      expect { @site.process }.to raise_error(RuntimeError)
-    end
+    )
+    @site.prepare
+    @collection = Jekyll::Collection.new(@site, "fixture")
+    @site.data['en'] = { 'foo' => 'enbar', 'strings' => {
+                           'apple' => 'apple', 'ice cream' => 'ice cream'
+                         } }
+    @site.data['fr'] = { 'foo' => 'frbar', 'strings' => {
+                           'ice cream' => 'crème glacée'
+                         } }
   end
+  it "site.process throws FatalError if a subprocess fails" do
+    @thistestonly = false
+    semaphore = Mutex.new
+    Jekyll::Hooks.register(:site, :post_write) do |_site|
+      semaphore.synchronize {
+        unless @thistestonly
+          @thistestonly = true
+          raise 'fail fr intentionally'
+        end
+      }
+    end
+    expect { @site.process }.to raise_error(RuntimeError)
+  end
+end

--- a/spec/rspec/helper.rb
+++ b/spec/rspec/helper.rb
@@ -1,8 +1,37 @@
 require "rspec"
 require 'rspec/mocks'
 # require 'minitest/autorun'
+require 'simplecov'
+require 'simplecov-json'
+
+SimpleCov.configure do
+  enable_coverage :branch
+
+  # Track files in lib directory
+  track_files "lib/**/*.rb"
+
+  # Add filters for test and vendor files
+  add_filter '/spec/'
+  add_filter '/test/'
+  add_filter '/vendor/'
+  add_filter '/.bundle/'
+
+  # Configure output directory
+  coverage_dir File.join(File.dirname(__FILE__), '..', '..', 'coverage')
+
+  # Use JSON formatter
+  formatter SimpleCov::Formatter::JSONFormatter
+
+  # Minimum coverage threshold
+  minimum_coverage 0
+end
+
+SimpleCov.start
+
+# Require project files after SimpleCov.start
 require "jekyll/polyglot"
 require "jekyll"
+require 'codecov'
 
 Dir[File.expand_path("../../support/*.rb", __FILE__)].each do |v|
   require v

--- a/spec/rspec/helper.rb
+++ b/spec/rspec/helper.rb
@@ -4,7 +4,7 @@ require 'rspec/mocks'
 require "jekyll/polyglot"
 require "jekyll"
 
-Dir[File.expand_path("../../support/*.rb", __FILE__)].each do |v|
+Dir[File.expand_path("../../support/*.rb", __FILE__)].sort.each do |v|
   require v
 end
 

--- a/spec/rspec/helper.rb
+++ b/spec/rspec/helper.rb
@@ -4,7 +4,7 @@ require 'rspec/mocks'
 require "jekyll/polyglot"
 require "jekyll"
 
-Dir[File.expand_path("../../support/*.rb", __FILE__)].sort.each do |v|
+Dir[File.expand_path("../../support/*.rb", __FILE__)].each do |v|
   require v
 end
 

--- a/spec/support/jekyll.rb
+++ b/spec/support/jekyll.rb
@@ -68,8 +68,8 @@ module Jekyll
     # to use true or false on `#silence_stoudt`.
     # ------------------------------------------------------------------------
 
-    def capture_stdout(&block)
-      silence_stdout true, &block
+    def capture_stdout(&)
+      silence_stdout(true, &)
     end
 
     # ------------------------------------------------------------------------

--- a/spec/support/jekyll.rb
+++ b/spec/support/jekyll.rb
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------------
-# Frozen-string-literal: true
-# Copyright: 2012 - 2016 - MIT License
 # Encoding: utf-8
+# Copyright: 2012 - 2016 - MIT License
+# Frozen-string-literal: true
 # ----------------------------------------------------------------------------
 
 require "nokogiri"
@@ -51,12 +51,12 @@ module Jekyll
       output  = yield
 
       if return_stringio
-        return [
+        [
           stdout.string,
           stderr.string
         ]
       else
-        return output
+        output
       end
     ensure
       $stdout = old_stdout

--- a/test.sh
+++ b/test.sh
@@ -11,13 +11,19 @@ NC='\033[0m' # No Color
 echo -e "${GREEN}Running RuboCop...${NC}"
 bundle exec rubocop
 
-echo -e "\n${GREEN}Running RSpec tests...${NC}"
-bundle exec rspec --format RspecJunitFormatter --out rspec.xml
+echo -e "${GREEN}Running RSpec tests with coverage...${NC}"
+COVERAGE=true bundle exec rspec --format RspecJunitFormatter --out rspec.xml
 
 # Check if tests passed
 if [ $? -eq 0 ]; then
-  echo -e "\n${GREEN}All tests passed!${NC}"
+    echo -e "${GREEN}Tests passed!${NC}"
+    
+    # Upload coverage to Codecov if we're in CI
+    if [ "$CI" = "true" ]; then
+        echo -e "${GREEN}Uploading coverage to Codecov...${NC}"
+        bash <(curl -s https://codecov.io/bash) -f "coverage/.last_run.json"
+    fi
 else
-  echo -e "\n${RED}Tests failed!${NC}"
-  exit 1
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
 fi 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Running RuboCop...${NC}"
+bundle exec rubocop
+
+echo -e "\n${GREEN}Running RSpec tests...${NC}"
+bundle exec rspec --format RspecJunitFormatter --out rspec.xml
+
+# Check if tests passed
+if [ $? -eq 0 ]; then
+  echo -e "\n${GREEN}All tests passed!${NC}"
+else
+  echo -e "\n${RED}Tests failed!${NC}"
+  exit 1
+fi 

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ echo -e "${GREEN}Running RuboCop...${NC}"
 bundle exec rubocop
 
 echo -e "${GREEN}Running RSpec tests with coverage...${NC}"
-COVERAGE=true bundle exec rspec --format RspecJunitFormatter --out rspec.xml
+COVERAGE=true bundle exec rspec --format RspecJunitFormatter --out rspec.xml --format json --out rspec.json
 
 # Check if tests passed
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
## 🔤 Polyglot PR

> This PR is a smorgasbord of changes to accomplish before 1.10 , which is still in progress. 🚧 

* reassigns `all_langs` from https://github.com/untra/polyglot/issues/233#issuecomment-2629086733 to improve custom asset generation
* improves assignment of custom permalinks per post with different languages and tests #224 
* creates a `test.sh` file to assist with quality
* adds codecov to measure coverage as part of circleci build
* strictly requires ruby 3.1 , to address ongoing security dependency updates

<!-- thanks for making a pull request! you are a handsome and kind individual, and you should be proud of your accomplishments -->

![add a sweet (optional) meme](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExMm5udWhyZGdueXYyb203M3BrbTJqOXBpMDJqdzVuaG1pY2MwMTdnYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o6Mb5gey34Hbz2lG0/giphy.gif)

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [x] Ops wrangling (automation or test improvements)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [ ] If modifying code, at least one test has been added to the suite
