### PR TITLE
Update redirect script to include hash anchors in URLs

### DIFF
--- a/site/_layouts/redirect.html
+++ b/site/_layouts/redirect.html
@@ -10,7 +10,7 @@
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
   <link rel="canonical" {% static_href %}href="{{ redirectTo }}"{% endstatic_href %}>
-  <script>location="{{ redirectTo }}"</script>
+  <script>location="{{ redirectTo }}" + window.location.hash</script>
   <meta http-equiv="refresh" content="0; url={{ redirectTo }}">
   <meta name="robots" content="noindex">
   <h1>Redirecting&hellip;</h1>


### PR DESCRIPTION
## 🔤 Polyglot PR

> Implements #274 solution from @GruberMarkus for preserving anchor links in redirect in redirect.html

Adding `+ window.location.hash` allows the client-side JavaScript redirect to correctly preserve and pass on any URL fragment identifier or anchor link that was present in the original URL.

<!-- thanks for making a pull request! you are a handsome and kind individual, and you should be proud of your accomplishments -->

![add a sweet (optional) meme](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWQ0ajRhZGZseHY0b3NlYWZyYXh1YXd0djNuNWdwM2w0NXphczhyaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/lXsYRXiDYse0DsAUAD/giphy.gif)

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [ ] If modifying code, at least one test has been added to the suite
