### PR TITLE
about page formatting updates, site.rendered_lang words

### DIFF
--- a/site/about.ar.md
+++ b/site/about.ar.md
@@ -46,29 +46,52 @@ url: https://polyglot.untra.io
 
 #### أدوات Liquid
 أدوات Liquid التالية متاحة للاستخدام مع jekyll-polyglot:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` يشير مباشرة إلى مصفوفة `languages` في _config.yml. يمكن الوصول إليه عبر Liquid.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` يشير مباشرة إلى سلسلة `default_lang` في _config.yml. يمكن الوصول إليه عبر Liquid.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang` هو رمز المنطقة الذي يتم بناء الصفحة له. هذا `"de"` للنسخة الألمانية من الصفحة، `"es"` للنسخة الإسبانية، وهكذا. يمكن الوصول إليه عبر Liquid.
 
 باستخدام هذه الأدوات، يمكنك تحديد كيفية إرفاق المحتوى الغني الصحيح.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+المتغير `page.rendered_lang` يشير إلى اللغة الفعلية لمحتوى الصفحة، مما يسمح للقوالب باكتشاف متى يتم تقديم الصفحة كمحتوى احتياطي.
 
 ### دعم Github Pages
 بشكل افتراضي، يمنع Github [مدونات Jekyll من استخدام الإضافات](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides). يتم ذلك عمدًا لمنع تشغيل التعليمات البرمجية الضارة على خوادم Github. على الرغم من أن هذا يجعل استخدام Polyglot (وإضافات Jekyll الأخرى) أصعب، إلا أنه لا يزال ممكنًا.

--- a/site/about.de.md
+++ b/site/about.de.md
@@ -46,29 +46,52 @@ Rich Content ist interaktiv, auffällig und besteht aus kürzeren Zeichenketten.
 
 #### Liquid-Werkzeuge
 Die folgenden Liquid-Werkzeuge sind für die Verwendung mit jekyll-polyglot verfügbar:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` zeigt direkt auf das `languages`-Array in _config.yml. Es kann über Liquid aufgerufen werden.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` zeigt direkt auf die `default_lang`-Zeichenkette in _config.yml. Es kann über Liquid aufgerufen werden.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang` ist der Gebietsschema-Code, für den die Seite erstellt wird. Dies ist `"de"` für die deutsche Version einer Seite, `"es"` für die spanische Version usw. Es kann über Liquid aufgerufen werden.
 
 Mit diesen Werkzeugen können Sie angeben, wie der richtige Rich Content angehängt wird.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+Die Variable `page.rendered_lang` gibt die tatsächliche Sprache des Seiteninhalts an und ermöglicht es Templates zu erkennen, wenn eine Seite als Fallback-Inhalt bereitgestellt wird.
 
 ### Github Pages Unterstützung
 Standardmäßig verhindert Github, dass [Jekyll-Blogs Plugins verwenden](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides). Dies geschieht absichtlich, um zu verhindern, dass bösartiger Code auf Github-Servern ausgeführt wird. Obwohl dies die Verwendung von Polyglot (und anderen Jekyll-Plugins) erschwert, ist es dennoch möglich.

--- a/site/about.en.md
+++ b/site/about.en.md
@@ -46,29 +46,53 @@ Rich content is interactive, flashy, and composed of shorter strings. Think navb
 
 #### Liquid Tools
 The following liquid tools are available for use with jekyll-polyglot:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` points directly to the `languages` array in _config.yml . It can be accessed through liquid.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` points directly to the `default_lang` string in _config.yml . It can be accessed through liquid.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.active_lang` is the locale code the page is being built for. This is `"de"` for the german version of a page, `"es"` for the spanish version, and so on. It can be accessed through liquid.
 
-Using these tools, you can specify how to attach the correct rich content
+Using these tools, you can specify how to attach the correct rich content.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+The `page.rendered_lang` variable that indicates the actual language of a page's content, Allowing templates to detect when a page is being served as fallback content.
 
 ### Github Pages Support
 By default github prevents [jekyll blogs from using plugins](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides). This is done intentionally to prevent malicious code from being executed on github servers. Although this makes using Polyglot (and other jekyll plugins) harder to use, it's still doable.
@@ -81,6 +105,7 @@ You can do this by maintaining your Jekyll content on a separate branch, and onl
 #### Automate it!
 
 This process is helped tremendously with a simple script that will build your website and commit the `_site/` folder to your gh-pages. A lot of people have one. [Here's one](http://www.jokecamp.com/blog/Simple-jekyll-deployment-with-a-shell-script-and-github/). [Here's another](https://gist.github.com/cobyism/4730490). Here is [my publish script](https://github.com/untra/polyglot/blob/main/publi.sh):
+
 ```bash
 #! /bin/sh
 # change the branch names appropriately

--- a/site/about.es.md
+++ b/site/about.es.md
@@ -46,29 +46,52 @@ El contenido rico es interactivo, llamativo y compuesto de cadenas más cortas. 
 
 #### Herramientas Liquid
 Las siguientes herramientas Liquid están disponibles para usar con jekyll-polyglot:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` apunta directamente al array `languages` en _config.yml. Se puede acceder a través de Liquid.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` apunta directamente a la cadena `default_lang` en _config.yml. Se puede acceder a través de Liquid.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang` es el código de localización para el que se está construyendo la página. Esto es `"de"` para la versión alemana de una página, `"es"` para la versión española, y así sucesivamente. Se puede acceder a través de Liquid.
 
 Usando estas herramientas, puedes especificar cómo adjuntar el contenido rico correcto.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+La variable `page.rendered_lang` indica el idioma real del contenido de una página, permitiendo que las plantillas detecten cuando una página se está sirviendo como contenido de respaldo.
 
 ### Soporte de Github Pages
 Por defecto, Github impide que los [blogs Jekyll usen plugins](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides). Esto se hace intencionalmente para evitar que código malicioso se ejecute en los servidores de Github. Aunque esto hace que usar Polyglot (y otros plugins de Jekyll) sea más difícil, todavía es posible.

--- a/site/about.fr.md
+++ b/site/about.fr.md
@@ -46,29 +46,52 @@ Le contenu riche est interactif, flashy et composé de chaînes plus courtes. Pe
 
 #### Outils Liquid
 Les outils Liquid suivants sont disponibles pour utilisation avec jekyll-polyglot:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` pointe directement vers le tableau `languages` dans _config.yml. Il peut être accédé via Liquid.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` pointe directement vers la chaîne `default_lang` dans _config.yml. Il peut être accédé via Liquid.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang` est le code de locale pour lequel la page est construite. C'est `"de"` pour la version allemande d'une page, `"es"` pour la version espagnole, et ainsi de suite. Il peut être accédé via Liquid.
 
 En utilisant ces outils, vous pouvez spécifier comment attacher le bon contenu riche.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+La variable `page.rendered_lang` indique la langue réelle du contenu d'une page, permettant aux templates de détecter quand une page est servie comme contenu de repli.
 
 ### Support Github Pages
 Par défaut, Github empêche les [blogs Jekyll d'utiliser des plugins](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides). Ceci est fait intentionnellement pour empêcher l'exécution de code malveillant sur les serveurs Github. Bien que cela rende l'utilisation de Polyglot (et d'autres plugins Jekyll) plus difficile, c'est toujours faisable.

--- a/site/about.he.md
+++ b/site/about.he.md
@@ -46,29 +46,52 @@ url: https://polyglot.untra.io
 
 #### כלי Liquid
 כלי ה-Liquid הבאים זמינים לשימוש עם jekyll-polyglot:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` מצביע ישירות למערך `languages` ב-_config.yml. ניתן לגשת אליו דרך Liquid.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` מצביע ישירות למחרוזת `default_lang` ב-_config.yml. ניתן לגשת אליו דרך Liquid.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang` הוא קוד המקום שהדף נבנה עבורו. זה `"de"` עבור הגרסה הגרמנית של דף, `"es"` עבור הגרסה הספרדית, וכן הלאה. ניתן לגשת אליו דרך Liquid.
 
 באמצעות כלים אלה, תוכלו לציין כיצד לצרף את התוכן העשיר הנכון.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+המשתנה `page.rendered_lang` מציין את השפה בפועל של תוכן הדף, מה שמאפשר לתבניות לזהות מתי דף מוגש כתוכן גיבוי.
 
 ### תמיכה ב-Github Pages
 כברירת מחדל, Github מונע מ[בלוגים של Jekyll להשתמש בתוספים](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides). זה נעשה בכוונה כדי למנוע מקוד זדוני לרוץ על שרתי Github. למרות שזה מקשה על השימוש ב-Polyglot (ותוספים אחרים של Jekyll), זה עדיין אפשרי.

--- a/site/about.it.md
+++ b/site/about.it.md
@@ -46,29 +46,52 @@ I contenuti ricchi sono interattivi, appariscenti e composti da stringhe più br
 
 #### Strumenti Liquid
 I seguenti strumenti liquid sono disponibili per l'uso con jekyll-polyglot:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` punta direttamente all'array `languages` in _config.yml. Può essere accessibile tramite liquid.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` punta direttamente alla stringa `default_lang` in _config.yml. Può essere accessibile tramite liquid.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang` è il codice locale per cui la pagina viene costruita. Questo è `"de"` per la versione tedesca di una pagina, `"es"` per la versione spagnola, e così via. Può essere accessibile tramite liquid.
 
 Usando questi strumenti, puoi specificare come allegare i contenuti ricchi corretti.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+La variabile `page.rendered_lang` indica la lingua effettiva del contenuto di una pagina, permettendo ai template di rilevare quando una pagina viene servita come contenuto di fallback.
 
 ### Supporto GitHub Pages
 Per impostazione predefinita, GitHub impedisce ai [blog Jekyll di usare plugin](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides). Questo viene fatto intenzionalmente per prevenire l'esecuzione di codice malevolo sui server GitHub. Anche se questo rende l'uso di Polyglot (e altri plugin Jekyll) più difficile, è comunque fattibile.

--- a/site/about.jp.md
+++ b/site/about.jp.md
@@ -46,29 +46,52 @@ url: https://polyglot.untra.io
 
 #### Liquidツール
 以下のLiquidツールはjekyll-polyglotで使用できます：
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages`は_config.ymlの`languages`配列を直接指します。Liquidを通じてアクセスできます。
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang`は_config.ymlの`default_lang`文字列を直接指します。Liquidを通じてアクセスできます。
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang`はページがビルドされているロケールコードです。ページのドイツ語版は`"de"`、スペイン語版は`"es"`などです。Liquidを通じてアクセスできます。
 
 これらのツールを使用して、正しいリッチコンテンツを添付する方法を指定できます。
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+`page.rendered_lang`変数はページコンテンツの実際の言語を示し、テンプレートがページがフォールバックコンテンツとして提供されているかどうかを検出できるようにします。
 
 ### Github Pagesサポート
 デフォルトでは、Githubは[JekyllブログがプラグインGを使用することを防ぎます](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides)。これは悪意のあるコードがGithubサーバーで実行されることを防ぐために意図的に行われています。これによりPolyglot（および他のJekyllプラグイン）の使用は難しくなりますが、それでも可能です。

--- a/site/about.ko.md
+++ b/site/about.ko.md
@@ -46,29 +46,52 @@ url: https://polyglot.untra.io
 
 #### Liquid 도구
 다음 Liquid 도구들은 jekyll-polyglot과 함께 사용할 수 있습니다:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages`는 _config.yml의 `languages` 배열을 직접 가리킵니다. Liquid를 통해 접근할 수 있습니다.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang`은 _config.yml의 `default_lang` 문자열을 직접 가리킵니다. Liquid를 통해 접근할 수 있습니다.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang`은 페이지가 빌드되는 로케일 코드입니다. 페이지의 독일어 버전은 `"de"`, 스페인어 버전은 `"es"` 등입니다. Liquid를 통해 접근할 수 있습니다.
 
 이 도구들을 사용하여 올바른 리치 컨텐츠를 첨부하는 방법을 지정할 수 있습니다.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+`page.rendered_lang` 변수는 페이지 컨텐츠의 실제 언어를 나타내며, 템플릿이 페이지가 폴백 컨텐츠로 제공되고 있는지 감지할 수 있게 합니다.
 
 ### Github Pages 지원
 기본적으로 Github은 [Jekyll 블로그가 플러그인을 사용하는 것을 방지](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides)합니다. 이것은 악성 코드가 Github 서버에서 실행되는 것을 방지하기 위해 의도적으로 수행됩니다. 이것이 Polyglot(및 다른 Jekyll 플러그인) 사용을 더 어렵게 만들지만, 여전히 가능합니다.

--- a/site/about.nl.md
+++ b/site/about.nl.md
@@ -46,29 +46,52 @@ Rijke content is interactief, flitsend en bestaat uit kortere strings. Denk aan 
 
 #### Liquid-tools
 De volgende Liquid-tools zijn beschikbaar voor gebruik met jekyll-polyglot:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` wijst direct naar de `languages` array in _config.yml. Het kan worden benaderd via Liquid.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` wijst direct naar de `default_lang` string in _config.yml. Het kan worden benaderd via Liquid.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang` is de locale code waarvoor de pagina wordt gebouwd. Dit is `"de"` voor de Duitse versie van een pagina, `"es"` voor de Spaanse versie, enzovoort. Het kan worden benaderd via Liquid.
 
 Met behulp van deze tools kun je specificeren hoe de juiste rijke content moet worden gekoppeld.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+De variabele `page.rendered_lang` geeft de werkelijke taal van de pagina-inhoud aan, waardoor templates kunnen detecteren wanneer een pagina als fallback-content wordt weergegeven.
 
 ### Github Pages-ondersteuning
 Standaard voorkomt Github dat [Jekyll-blogs plugins gebruiken](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides). Dit wordt opzettelijk gedaan om te voorkomen dat kwaadaardige code op Github-servers wordt uitgevoerd. Hoewel dit het gebruik van Polyglot (en andere Jekyll-plugins) moeilijker maakt, is het nog steeds mogelijk.

--- a/site/about.pt-BR.md
+++ b/site/about.pt-BR.md
@@ -46,29 +46,52 @@ Conteúdo rico é interativo, chamativo e composto de strings mais curtas. Pense
 
 #### Ferramentas Liquid
 As seguintes ferramentas Liquid estão disponíveis para uso com jekyll-polyglot:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` aponta diretamente para o array `languages` no _config.yml. Pode ser acessado através do Liquid.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` aponta diretamente para a string `default_lang` no _config.yml. Pode ser acessado através do Liquid.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang` é o código de localidade para o qual a página está sendo construída. Isso é `"de"` para a versão alemã de uma página, `"es"` para a versão espanhola, e assim por diante. Pode ser acessado através do Liquid.
 
 Usando essas ferramentas, você pode especificar como anexar o conteúdo rico correto.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+A variável `page.rendered_lang` indica o idioma real do conteúdo de uma página, permitindo que os templates detectem quando uma página está sendo servida como conteúdo de fallback.
 
 ### Suporte ao Github Pages
 Por padrão, o Github impede que [blogs Jekyll usem plugins](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides). Isso é feito intencionalmente para evitar que código malicioso seja executado nos servidores do Github. Embora isso torne o uso do Polyglot (e outros plugins Jekyll) mais difícil, ainda é possível.

--- a/site/about.ru.md
+++ b/site/about.ru.md
@@ -46,29 +46,52 @@ url: https://polyglot.untra.io
 
 #### Инструменты Liquid
 Следующие инструменты Liquid доступны для использования с jekyll-polyglot:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` указывает напрямую на массив `languages` в _config.yml. К нему можно получить доступ через Liquid.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` указывает напрямую на строку `default_lang` в _config.yml. К нему можно получить доступ через Liquid.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang` — это код локали, для которой строится страница. Это `"de"` для немецкой версии страницы, `"es"` для испанской версии и так далее. К нему можно получить доступ через Liquid.
 
 Используя эти инструменты, вы можете указать, как прикрепить правильный богатый контент.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+Переменная `page.rendered_lang` указывает фактический язык содержимого страницы, позволяя шаблонам определять, когда страница отображается как резервный контент.
 
 ### Поддержка Github Pages
 По умолчанию Github не позволяет [блогам Jekyll использовать плагины](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides). Это сделано намеренно, чтобы предотвратить выполнение вредоносного кода на серверах Github. Хотя это усложняет использование Polyglot (и других плагинов Jekyll), это все еще возможно.

--- a/site/about.tr.md
+++ b/site/about.tr.md
@@ -46,29 +46,52 @@ Zengin içerik etkileşimli, gösterişli ve daha kısa dizelerden oluşur. Gezi
 
 #### Liquid Araçları
 Aşağıdaki liquid araçları jekyll-polyglot ile kullanılabilir:
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` doğrudan _config.yml'deki `languages` dizisine işaret eder. Liquid aracılığıyla erişilebilir.
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` doğrudan _config.yml'deki `default_lang` dizesine işaret eder. Liquid aracılığıyla erişilebilir.
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang`, sayfanın oluşturulduğu yerel ayar kodudur. Bu, bir sayfanın Almanca sürümü için `"de"`, İspanyolca sürümü için `"es"` vb. şeklindedir. Liquid aracılığıyla erişilebilir.
 
 Bu araçları kullanarak, doğru zengin içeriği nasıl ekleyeceğinizi belirleyebilirsiniz.
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+`page.rendered_lang` değişkeni, bir sayfanın içeriğinin gerçek dilini belirtir ve şablonların bir sayfanın yedek içerik olarak sunulup sunulmadığını algılamasını sağlar.
 
 ### GitHub Pages Desteği
 Varsayılan olarak GitHub, [Jekyll bloglarının eklenti kullanmasını](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides) engeller. Bu, GitHub sunucularında kötü amaçlı kodun çalıştırılmasını önlemek için kasıtlı olarak yapılır. Bu, Polyglot'u (ve diğer Jekyll eklentilerini) kullanmayı zorlaştırsa da, yine de yapılabilir.

--- a/site/about.zh-CN.md
+++ b/site/about.zh-CN.md
@@ -46,29 +46,52 @@ url: https://polyglot.untra.io
 
 #### Liquid 工具
 以下 Liquid 工具可与 jekyll-polyglot 一起使用：
+
 * **site.languages**
-```html
+
+{% highlight html %}
+{% raw %}
 {% for lang in site.languages %}
-{{lang}}
+  {{lang}}
 {% endfor %}
-```
+{% endraw %}
+{% endhighlight %}
+
 `site.languages` 直接指向 _config.yml 中的 `languages` 数组。可以通过 Liquid 访问。
 
 * **site.default_lang**
-```html
-{{site.default_lang}}
-```
+{% highlight html %}
+{% raw %}
+  {{site.default_lang}}
+{% endraw %}
+{% endhighlight %}
+
 `site.default_lang` 直接指向 _config.yml 中的 `default_lang` 字符串。可以通过 Liquid 访问。
 
 * **site.active_lang**
-```html
+{% highlight html %}
+{% raw %}
 {% if site.active_lang == "es" %}
-<h1>Hola! Como estas?</h1>
+  <h1>Hola! Como estas?</h1>
 {% endif %}
-```
+{% endraw %}
+{% endhighlight %}
 `site.active_lang` 是正在构建页面的区域代码。德语版页面是 `"de"`，西班牙语版是 `"es"`，依此类推。可以通过 Liquid 访问。
 
 使用这些工具，您可以指定如何附加正确的富内容。
+
+* **page.rendered_lang**
+{% highlight html %}
+{% raw %}
+{% if page.rendered_lang == site.active_lang %}
+  <p>Welcome to our {{ site.active_lang }} webpage!</p>
+{% else %}
+  <p>webpage available in {{ page.rendered_lang }} only.</p>
+{% endif %}
+{% endraw %}
+{% endhighlight %}
+
+`page.rendered_lang` 变量表示页面内容的实际语言，允许模板检测页面何时作为回退内容提供。
 
 ### Github Pages 支持
 默认情况下，Github 阻止 [Jekyll 博客使用插件](https://help.github.com/articles/using-jekyll-with-pages/#configuration-overrides)。这是故意的，以防止恶意代码在 Github 服务器上执行。虽然这使得使用 Polyglot（和其他 Jekyll 插件）更加困难，但仍然可行。

--- a/site/complex-permalink.tr.md
+++ b/site/complex-permalink.tr.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Çok uzun bir kalıcı bağlantı
-permalink: cok-uzun-bir/kalici-baglanti/
+permalink: cok-uzun-bir/permalink/
 lang: tr
 page_id: complex-permalink
 description: bu sayfa jekyll polyglot'un site yapısını korurken özelleştirilmiş kalıcı bağlantıları nasıl oluşturup sürdürebileceğini gösterir.


### PR DESCRIPTION
## 🔤 Polyglot PR

> update about page html formatting and raw highlighting , for multi-language translations
> adds words for `page.rendered_lang` from #283 

<!-- thanks for making a pull request! you are a handsome and kind individual, and you should be proud of your accomplishments -->

![add a sweet (optional) meme](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExN3g0MWZyNnRxM2NpaWhxZ2theG90d2NqMGk5Z3IwejNzbmRqM3BxMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/AsKkJB6JbFGiQ/giphy.gif)

## Type of change

- [x] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [ ] If modifying code, at least one test has been added to the suite
