### PR TITLE
Feature/jekyll redirect plugin tests, sublanguage redirect support

### DIFF
--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -178,22 +178,42 @@ module Jekyll
     end
 
     def assignPageRedirects(doc, docs)
-      pageId = doc.data['page_id']
-      if !pageId.nil? && !pageId.empty?
-        redirects = []
+      # Preserve and normalize user-defined redirect_from
+      user_redirects = doc.data['redirect_from'] || []
+      user_redirects = [user_redirects] unless user_redirects.is_a?(Array)
 
-        docs_with_same_id = docs.select { |dd| dd.data['page_id'] == pageId }
+      # Determine document language
+      doc_lang = doc.data['lang'] || derive_lang_from_path(doc) || @default_lang
 
-        # For each document with the same page_id
-        docs_with_same_id.each do |dd|
-          # Add redirect if it's a different permalink
-          if dd.data['permalink'] != doc.data['permalink']
-            redirects << dd.data['permalink']
+      # Scope user-defined redirects to document's language if non-default
+      if doc_lang != @default_lang && !user_redirects.empty?
+        user_redirects = user_redirects.map do |redirect_path|
+          # Normalize path to start with /
+          redirect_path = "/#{redirect_path}" unless redirect_path.start_with?('/')
+          # Only prefix if not already prefixed with this language
+          if redirect_path.start_with?("/#{doc_lang}/")
+            redirect_path
+          else
+            "/#{doc_lang}#{redirect_path}"
           end
         end
-
-        doc.data['redirect_from'] = redirects
       end
+
+      # Compute page_id based redirects (cross-language)
+      computed_redirects = []
+      pageId = doc.data['page_id']
+      if !pageId.nil? && !pageId.empty?
+        docs_with_same_id = docs.select { |dd| dd.data['page_id'] == pageId }
+        docs_with_same_id.each do |dd|
+          if dd.data['permalink'] != doc.data['permalink']
+            computed_redirects << dd.data['permalink']
+          end
+        end
+      end
+
+      # Merge user-defined and computed redirects, removing duplicates
+      all_redirects = (user_redirects + computed_redirects).uniq
+      doc.data['redirect_from'] = all_redirects unless all_redirects.empty?
     end
 
     def assignPageLanguagePermalinks(doc, docs)


### PR DESCRIPTION
## 🔤 Polyglot PR

closes #284 , implementing a fix to ensure Adding frontmatter to a page/post to `redirect_from` applies correctly across sublanguages

<!-- thanks for making a pull request! you are a handsome and kind individual, and you should be proud of your accomplishments -->

![add a sweet (optional) meme](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExc2lrODVsY205MHlmZGpsZXJlZmgxOHh0bTlibHUyODc4YnVjZXR0NCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3orif0Pxk3I4WQj46k/giphy.gif)

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [ ] If modifying code, at least one test has been added to the suite
