### PR TITLE
htmlproofer, jekyll-seo-tag, lint and cicd adjustments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,15 @@ orbs:
   codecov: codecov/codecov@5.3.0
 
 jobs:
-  build:
+  lint:
     docker:
       - image: cimg/ruby:3.1
     steps:
-      - checkout 
+      - checkout
       - ruby/install-deps
       - run:
-          name: Make test.sh executable
-          command: chmod +x test.sh
+          name: RuboCop
+          command: bundle exec rubocop --format progress
 
   test:
     docker:
@@ -21,8 +21,8 @@ jobs:
       CI: 'true'
       CODECOV_TOKEN: ${CODECOV_TOKEN}
     steps:
-      - checkout 
-      - ruby/install-deps 
+      - checkout
+      - ruby/install-deps
       - run:
           name: Run tests and generate coverage
           command: ./test.sh
@@ -32,11 +32,27 @@ jobs:
           path: coverage
           destination: coverage
 
+  htmlproofer:
+    docker:
+      - image: cimg/ruby:3.1
+    steps:
+      - checkout
+      - ruby/install-deps
+      - run:
+          name: Build example site and run html-proofer
+          command: bundle exec rake htmlproofer
+      - store_artifacts:
+          path: site/_site
+          destination: site
+
 workflows:
   version: 2
-  build_and_test:     
-    jobs:           
-      - build        
-      - test:      
-          requires:  
-            - build
+  build_and_test:
+    jobs:
+      - lint
+      - test:
+          requires:
+            - lint
+      - htmlproofer:
+          requires:
+            - lint

--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,5 @@ end
 gem 'jekyll'
 gem 'jekyll-paginate'
 gem 'jekyll-redirect-from'
+gem 'jekyll-seo-tag', '~> 2.9.0'
 gem 'webrick', '>= 1.8.2'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 gem 'rake'
 group :test do
   gem 'codecov', '~> 0.6.0'
+  gem 'html-proofer', '5.1.1'
   gem 'minitest', '>= 5.16.3'
   gem 'nokogiri', '>= 1.14.3'
   gem 'rspec', '>= 3.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
+    jekyll-seo-tag (2.9.0)
+      jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.19.5)
@@ -211,6 +213,7 @@ DEPENDENCIES
   jekyll-paginate
   jekyll-polyglot!
   jekyll-redirect-from
+  jekyll-seo-tag (~> 2.9.0)
   minitest (>= 5.16.3)
   nokogiri (>= 1.14.3)
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,23 +7,43 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    Ascii85 (2.0.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    afm (0.2.2)
     ast (2.4.2)
-    bigdecimal (3.1.9)
+    async (2.24.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.9)
+      metrics (~> 0.12)
+      traces (~> 0.15)
+    benchmark (0.5.0)
+    bigdecimal (3.3.1)
     codecov (0.6.0)
       simplecov (>= 0.15, < 0.22)
     colorator (1.1.0)
     concurrent-ruby (1.3.3)
+    console (1.30.2)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     diff-lcs (1.5.1)
     docile (1.4.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
+    ethon (0.18.0)
+      ffi (>= 1.15.0)
+      logger
     eventmachine (1.2.7)
-    ffi (1.17.0)
-    ffi (1.17.0-x64-mingw-ucrt)
-    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.4)
+    ffi (1.17.4-x64-mingw-ucrt)
+    ffi (1.17.4-x86_64-darwin)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     google-protobuf (4.27.5)
       bigdecimal
@@ -34,9 +54,21 @@ GEM
     google-protobuf (4.27.5-x86_64-darwin)
       bigdecimal
       rake (>= 13)
+    hashery (2.1.2)
+    html-proofer (5.1.1)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      benchmark (~> 0.5)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    io-event (1.11.2)
     jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -60,7 +92,7 @@ GEM
       sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.9.1)
+    json (2.19.5)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -70,15 +102,17 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
+    metrics (0.12.2)
     mini_portile2 (2.8.9)
     minitest (5.23.1)
-    nokogiri (1.18.9)
+    nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.18.9-x64-mingw-ucrt)
+    nokogiri (1.18.10-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-darwin)
+    nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.7.0)
@@ -86,7 +120,13 @@ GEM
       racc
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.5)
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
+    public_suffix (6.0.2)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -129,6 +169,7 @@ GEM
     rubocop-rspec (3.4.0)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
+    ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
     sass-embedded (1.77.4)
       google-protobuf (>= 3.25, < 5.0)
@@ -148,8 +189,15 @@ GEM
     simplecov_json_formatter (0.1.4)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    traces (0.15.2)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
     unicode-display_width (2.5.0)
     webrick (1.8.2)
+    yell (2.2.2)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby
@@ -158,6 +206,7 @@ PLATFORMS
 
 DEPENDENCIES
   codecov (~> 0.6.0)
+  html-proofer (= 5.1.1)
   jekyll
   jekyll-paginate
   jekyll-polyglot!

--- a/README.md
+++ b/README.md
@@ -198,14 +198,14 @@ For proper canonical URL handling on multilingual sites, we recommend using Poly
 
 **Setup with jekyll-seo-tag:**
 
-If you're using [jekyll-seo-tag](https://github.com/jekyll/jekyll-seo-tag), disable its canonical output and let Polyglot handle it:
+If you're using [jekyll-seo-tag](https://github.com/jekyll/jekyll-seo-tag), you can disable its canonical output and let Polyglot handle it:
 
 ```liquid
 {% seo canonical=false %}
 {% I18n_Headers %}
 ```
 
-The `canonical=false` option is available in jekyll-seo-tag v2.9.0+ (see [PR #521](https://github.com/jekyll/jekyll-seo-tag/pull/521)).
+The `canonical=false` option is available in jekyll-seo-tag v2.9.0+
 
 **Fallback Canonical Behavior:**
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,22 @@
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 task :default => [:spec]
+
+desc 'Build the example site at ./site'
+task :site_build do
+  Dir.chdir('site') do
+    sh 'bundle exec jekyll build'
+  end
+end
+
+desc 'Run html-proofer on the built example site'
+task :htmlproofer => [:site_build] do
+  require 'html-proofer'
+  HTMLProofer.check_directory(
+    './site/_site',
+    disable_external: true,
+    allow_hash_href: true,
+    root_dir: './site/_site',
+    swap_urls: { %r{^https://polyglot\.untra\.io} => '' }
+  ).run
+end

--- a/lib/jekyll/polyglot/liquid/tags/i18n_headers.rb
+++ b/lib/jekyll/polyglot/liquid/tags/i18n_headers.rb
@@ -12,92 +12,87 @@ module Jekyll
         def render(context)
           site = context.registers[:site]
           page = context.registers[:page]
-          permalink = page['permalink'] || page['url'] || ''
-          permalink = "/#{permalink}" unless permalink.start_with?("/")
-          # Strip language prefix from permalink for matching (e.g., /es/about -> /about)
-          normalized_permalink = permalink.delete_prefix("/#{site.active_lang}/")
-          normalized_permalink = "/#{normalized_permalink}" unless normalized_permalink.start_with?("/")
-          page_id = page['page_id']
+          permalink = normalize_permalink(page['permalink'] || page['url'] || '')
+          normalized_permalink = strip_lang_prefix(permalink, site.active_lang)
           permalink_lang = page['permalink_lang']
+          site_url = resolve_site_url(site)
+
+          lang_to_permalink = build_lang_to_permalink(site, page['page_id'], normalized_permalink)
+
+          canonical_tag(site, site_url, lang_to_permalink, permalink_lang, normalized_permalink) +
+            hreflang_tags(site, site_url, lang_to_permalink, permalink_lang, normalized_permalink)
+        end
+
+        private
+
+        def normalize_permalink(permalink)
+          permalink.start_with?('/') ? permalink : "/#{permalink}"
+        end
+
+        def strip_lang_prefix(permalink, active_lang)
+          stripped = permalink.delete_prefix("/#{active_lang}/")
+          stripped.start_with?('/') ? stripped : "/#{stripped}"
+        end
+
+        def resolve_site_url(site)
+          return @url unless @url.empty?
+
           baseurl = site.config['baseurl'] || ''
-          site_url = @url.empty? ? site.config['url'] + baseurl : @url
-          i18n = ""
+          site.config['url'] + baseurl
+        end
 
-          # Find all documents with the same page_id
+        def build_lang_to_permalink(site, page_id, normalized_permalink)
           valid_languages = ([site.default_lang] + site.languages).uniq
-
-          # Find all documents and pages that are translations of this page
-          # Match by page_id if set, otherwise match by permalink
           all_content = site.collections.values.flat_map(&:docs) + site.pages
-          docs_with_same_id = if page_id
-            all_content
-              .filter { |doc| !doc.data['page_id'].nil? }
-              .select { |doc| doc.data['page_id'] == page_id }
+          matching = if page_id
+            all_content.select { |doc| doc.data['page_id'] == page_id }
           else
-            # No page_id, match by permalink instead
-            # Use normalized permalink to handle language prefixes
-            all_content
-              .filter { |doc| !doc.data['permalink'].nil? }
-              .select { |doc| doc.data['permalink'] == normalized_permalink }
+            all_content.select { |doc| doc.data['permalink'] == normalized_permalink }
           end
-
-          # Build a hash of lang => permalink for all matching docs
-          # Filter by explicit lang to exclude unconfigured languages even after normalization
-          lang_to_permalink = docs_with_same_id
+          matching
             .reject { |doc| doc.data['lang'] && !valid_languages.include?(doc.data['lang']) }
             .to_h { |doc| [doc.data['lang'] || site.default_lang, doc.data['permalink']] }
-          end
+        end
 
-          # Determine if this page has an actual translation for the active language
+        def lookup_permalink(lang_to_permalink, permalink_lang, lang)
+          lang_to_permalink[lang] || (permalink_lang && permalink_lang[lang])
+        end
+
+        def with_lang_prefix(permalink, lang)
+          permalink.start_with?("/#{lang}/") ? permalink : "/#{lang}#{permalink}"
+        end
+
+        def canonical_tag(site, site_url, lang_to_permalink, permalink_lang, normalized_permalink)
           current_lang = site.active_lang
-          has_translation_for_current_lang = lang_to_permalink[current_lang] || (permalink_lang && permalink_lang[current_lang])
+          has_translation = lookup_permalink(lang_to_permalink, permalink_lang, current_lang)
+          use_default = site.fallback_canonical_to_default_lang && !has_translation && current_lang != site.default_lang
 
-          # Canonical URL logic:
-          # - If page has actual translation for current lang: canonical points to current lang URL
-          # - If page is fallback AND fallback_canonical_to_default_lang is enabled: canonical points to default lang URL
-          # - Otherwise: canonical points to current lang URL (backwards compatible)
-          current_permalink = lang_to_permalink[current_lang] || (permalink_lang && permalink_lang[current_lang]) || normalized_permalink
-          current_permalink = "/#{current_permalink}" unless current_permalink.start_with?("/")
-
-          use_default_lang_canonical = site.fallback_canonical_to_default_lang && !has_translation_for_current_lang && current_lang != site.default_lang
-
-          canonical_permalink = if use_default_lang_canonical
-            # Fallback page with option enabled: point to default language URL
-            default_permalink = lang_to_permalink[site.default_lang] || (permalink_lang && permalink_lang[site.default_lang]) || normalized_permalink
-            default_permalink = "/#{default_permalink}" unless default_permalink.start_with?("/")
-            default_permalink
+          canonical = if use_default
+            normalize_permalink(lookup_permalink(lang_to_permalink, permalink_lang, site.default_lang) || normalized_permalink)
           elsif current_lang == site.default_lang
-            current_permalink
+            normalize_permalink(lookup_permalink(lang_to_permalink, permalink_lang, current_lang) || normalized_permalink)
           else
-            # Don't add language prefix if it's already in the permalink
-            current_permalink.start_with?("/#{current_lang}/") ? current_permalink : "/#{current_lang}#{current_permalink}"
+            current = normalize_permalink(lookup_permalink(lang_to_permalink, permalink_lang, current_lang) || normalized_permalink)
+            with_lang_prefix(current, current_lang)
           end
-          i18n += "<link rel=\"canonical\" href=\"#{site_url}#{canonical_permalink}\"/>\n"
+          "<link rel=\"canonical\" href=\"#{site_url}#{canonical}\"/>\n"
+        end
 
-          # Get the default language permalink for x-default
-          default_lang_permalink = lang_to_permalink[site.default_lang] || (permalink_lang && permalink_lang[site.default_lang]) || normalized_permalink
-          default_lang_permalink = "/#{default_lang_permalink}" unless default_lang_permalink.start_with?("/")
+        def hreflang_tags(site, site_url, lang_to_permalink, permalink_lang, normalized_permalink)
+          default_permalink = normalize_permalink(lookup_permalink(lang_to_permalink, permalink_lang, site.default_lang) || normalized_permalink)
 
-          site.languages.each do |lang|
-            alt_permalink = lang_to_permalink[lang] || (permalink_lang && permalink_lang[lang]) || normalized_permalink
-            alt_permalink = "/#{alt_permalink}" unless alt_permalink.start_with?("/")
+          site.languages.map do |lang|
+            has_translation = lookup_permalink(lang_to_permalink, permalink_lang, lang)
+            next nil if !has_translation && lang != site.default_lang
 
-            # Skip hreflang for this language if no actual translation exists
-            # Only generate hreflang tags for languages that have real translated content
-            has_translation = lang_to_permalink[lang] || (permalink_lang && permalink_lang[lang])
-            next if !has_translation && lang != site.default_lang
-
-            i18n += if lang == site.default_lang
-              "<link rel=\"alternate\" hreflang=\"#{lang}\" href=\"#{site_url}#{alt_permalink}\"/>\n" \
-                "<link rel=\"alternate\" hreflang=\"x-default\" href=\"#{site_url}#{default_lang_permalink}\"/>\n"
+            alt = normalize_permalink(lookup_permalink(lang_to_permalink, permalink_lang, lang) || normalized_permalink)
+            if lang == site.default_lang
+              "<link rel=\"alternate\" hreflang=\"#{lang}\" href=\"#{site_url}#{alt}\"/>\n" \
+                "<link rel=\"alternate\" hreflang=\"x-default\" href=\"#{site_url}#{default_permalink}\"/>\n"
             else
-              # For non-default languages, use the language-specific permalink directly
-              # Don't add the language prefix if it's already in the permalink
-              lang_permalink = alt_permalink.start_with?("/#{lang}/") ? alt_permalink : "/#{lang}#{alt_permalink}"
-              "<link rel=\"alternate\" hreflang=\"#{lang}\" href=\"#{site_url}#{lang_permalink}\"/>\n"
+              "<link rel=\"alternate\" hreflang=\"#{lang}\" href=\"#{site_url}#{with_lang_prefix(alt, lang)}\"/>\n"
             end
-          end
-          i18n
+          end.compact.join
         end
       end
     end

--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -157,8 +157,10 @@ module Jekyll
         # FILTER: Skip documents whose explicit lang is not in configured languages.
         # Check the explicit value (not the fallback) so that documents with an
         # unconfigured lang like 'de' are excluded even if normalization would
-        # map them to default_lang.
-        if explicit_lang && !valid_languages.include?(explicit_lang)
+        # map them to default_lang. Compare case-insensitively so case-mismatched
+        # frontmatter (e.g. 'pt-br' vs configured 'pt-BR') is normalized below
+        # rather than rejected here.
+        if explicit_lang && valid_languages.none? { |l| l.downcase == explicit_lang.downcase }
           Jekyll.logger.warn "Polyglot:", "Skipping #{doc.relative_path} - lang '#{explicit_lang}' not in configured languages #{valid_languages.inspect}"
           next
         end

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -32,7 +32,7 @@ author:
 ga_tag: G-HWC3D32MT8
 
 
-plugins: [jekyll-polyglot, jekyll-paginate, jekyll-redirect-from]
+plugins: [jekyll-polyglot, jekyll-paginate, jekyll-redirect-from, jekyll-seo-tag]
 # Permalinks
 permalink: pretty
 

--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -7,6 +7,7 @@
   <meta name="title" content="{{ page.title }} &middot; {{ site.title }}">
   <meta name="description" content="{{ page.description | default: site.description[site.active_lang] }}">
   <meta name="keywords" content="{{ page.keywords | default: site.keywords[site.active_lang] }}">
+  {% seo canonical=false %}
   {% I18n_Headers %}
   <title>
     {% if page.title == "Home" %}

--- a/site/sample.md
+++ b/site/sample.md
@@ -2,7 +2,6 @@
 layout: page
 title: Sample rich text data
 permalink: sample/
-lang: site.data["active_lang"]
 ---
 {{ site.data["sample"][1] }}<br/>
 {{ site.data["sample"][2] }}<br/>

--- a/spec/jekyll/polyglot/patches/jekyll/site_spec.rb
+++ b/spec/jekyll/polyglot/patches/jekyll/site_spec.rb
@@ -3,7 +3,7 @@ require 'rspec/helper'
 require 'rspec'
 require 'tempfile'
 
-TestPage = Struct.new(:data)
+TestPage = Struct.new(:data, :url, :relative_path)
 
 describe Site do
   before do
@@ -1435,7 +1435,7 @@ describe Site do
         coordinated = @site.coordinate_documents(docs)
         coordinated_langs = coordinated.map { |d| d.data['lang'] }
 
-        expect(coordinated_langs).to include('en')  # default_lang always included
+        expect(coordinated_langs).to include('en') # default_lang always included
         expect(coordinated_langs).to include('es')
         expect(coordinated_langs).not_to include('de')
       end
@@ -1453,7 +1453,6 @@ describe Site do
 
         @site.coordinate_documents([doc])
       end
-    end
 
       it 'should not serve unconfigured language pages as default language content' do
         # Real-world scenario: site configured with limited languages for dev builds,
@@ -1465,26 +1464,14 @@ describe Site do
 
         # Simulate Jekyll::Page objects using OpenStruct (like site.pages)
         pages = [
-          OpenStruct.new(
-            data: { 'lang' => 'en', 'page_id' => 'home', 'permalink' => '/',
-                    'title' => 'The SQL Editor You Love' },
-            url: '/'
-          ),
-          OpenStruct.new(
-            data: { 'lang' => 'de', 'page_id' => 'home', 'permalink' => '/',
-                    'title' => 'Der SQL-Editor Ihrer Träume' },
-            url: '/'
-          ),
-          OpenStruct.new(
-            data: { 'lang' => 'pt-BR', 'page_id' => 'home', 'permalink' => '/',
-                    'title' => 'O Editor SQL dos Seus Sonhos' },
-            url: '/'
-          ),
-          OpenStruct.new(
-            data: { 'lang' => 'fr', 'page_id' => 'home', 'permalink' => '/',
-                    'title' => "L'éditeur SQL de vos rêves" },
-            url: '/'
-          )
+          TestPage.new({ 'lang' => 'en', 'page_id' => 'home', 'permalink' => '/',
+                         'title' => 'The SQL Editor You Love' }, '/'),
+          TestPage.new({ 'lang' => 'de', 'page_id' => 'home', 'permalink' => '/',
+                         'title' => 'Der SQL-Editor Ihrer Träume' }, '/'),
+          TestPage.new({ 'lang' => 'pt-BR', 'page_id' => 'home', 'permalink' => '/',
+                         'title' => 'O Editor SQL dos Seus Sonhos' }, '/'),
+          TestPage.new({ 'lang' => 'fr', 'page_id' => 'home', 'permalink' => '/',
+                         'title' => "L'éditeur SQL de vos rêves" }, '/')
         ]
 
         # Building for default language (en)
@@ -1539,6 +1526,7 @@ describe Site do
         coordinated_langs = coordinated.map { |d| d.data['lang'] }
         expect(coordinated_langs).not_to include('de')
       end
+    end
 
     describe 'assignPageLanguagePermalinks with unconfigured languages' do
       before do

--- a/spec/jekyll/polyglot/patches/jekyll/site_spec.rb
+++ b/spec/jekyll/polyglot/patches/jekyll/site_spec.rb
@@ -1,8 +1,9 @@
 require 'jekyll'
 require 'rspec/helper'
-require 'ostruct'
 require 'rspec'
 require 'tempfile'
+
+TestPage = Struct.new(:data)
 
 describe Site do
   before do
@@ -1066,25 +1067,21 @@ describe Site do
       @site.prepare
 
       # Create standalone pages (not in collections) with page_id - only English and Spanish translations
-      # Using OpenStruct to simulate Jekyll::Page objects with data hash
-      page_en = OpenStruct.new(
-        data: {
-          'layout' => 'page',
-          'title' => 'About Us',
-          'permalink' => '/about/',
-          'lang' => 'en',
-          'page_id' => 'about-page'
-        }
-      )
-      page_es = OpenStruct.new(
-        data: {
-          'layout' => 'page',
-          'title' => 'Sobre Nosotros',
-          'permalink' => '/es/sobre-nosotros/',
-          'lang' => 'es',
-          'page_id' => 'about-page'
-        }
-      )
+      # Using a TestPage Struct to simulate Jekyll::Page objects with data hash
+      page_en = TestPage.new({
+        'layout' => 'page',
+        'title' => 'About Us',
+        'permalink' => '/about/',
+        'lang' => 'en',
+        'page_id' => 'about-page'
+      })
+      page_es = TestPage.new({
+        'layout' => 'page',
+        'title' => 'Sobre Nosotros',
+        'permalink' => '/es/sobre-nosotros/',
+        'lang' => 'es',
+        'page_id' => 'about-page'
+      })
 
       # Add pages to site.pages (not to collections)
       @site.pages << page_en
@@ -1117,24 +1114,20 @@ describe Site do
 
       # Create standalone pages with same permalink but NO page_id - only lang differs
       # This is a common pattern: same permalink, different lang frontmatter
-      page_en = OpenStruct.new(
-        data: {
-          'layout' => 'page',
-          'title' => 'About Us',
-          'permalink' => '/about/',
-          'lang' => 'en'
-          # No page_id!
-        }
-      )
-      page_es = OpenStruct.new(
-        data: {
-          'layout' => 'page',
-          'title' => 'Sobre Nosotros',
-          'permalink' => '/about/',  # Same permalink as English
-          'lang' => 'es'
-          # No page_id!
-        }
-      )
+      page_en = TestPage.new({
+        'layout' => 'page',
+        'title' => 'About Us',
+        'permalink' => '/about/',
+        'lang' => 'en'
+        # No page_id!
+      })
+      page_es = TestPage.new({
+        'layout' => 'page',
+        'title' => 'Sobre Nosotros',
+        'permalink' => '/about/', # Same permalink as English
+        'lang' => 'es'
+        # No page_id!
+      })
 
       # Add pages to site.pages
       @site.pages << page_en
@@ -1167,14 +1160,12 @@ describe Site do
 
       # Create a single page WITHOUT lang frontmatter (common real-world case)
       # This page should only have English hreflang, not all languages
-      page_no_lang = OpenStruct.new(
-        data: {
-          'layout' => 'page',
-          'title' => 'About Us',
-          'permalink' => '/about/'
-          # No lang! This is the key case
-        }
-      )
+      page_no_lang = TestPage.new({
+        'layout' => 'page',
+        'title' => 'About Us',
+        'permalink' => '/about/'
+        # No lang! This is the key case
+      })
 
       # Add page to site.pages
       @site.pages << page_no_lang
@@ -1299,7 +1290,6 @@ describe Site do
       expect(output).to include('rel="canonical" href="https://test.github.io/es/sobre-nosotros/"')
       expect(output).to_not include('rel="canonical" href="https://test.github.io/about/"')
     end
-
 
     describe 'rendered_lang' do
       before do


### PR DESCRIPTION
## 🔤 Polyglot PR

* adds `html-proofer` test dep
* adds `jekyll-seo-tag` and implements it to complement @rathboma merged PR's
* rtl support for arabic and hebrew
* fixes broken tests in cicd, failing after some merges
* some readme word adjustments

<!-- thanks for making a pull request! you are a handsome and kind individual, and you should be proud of your accomplishments -->

![add a sweet (optional) meme](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExZnBxanl0cjZ3a3V0Y2Y0cjdwcm1jZjBtb2Jxd2FveXd1czhmeDloOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/QJtJ7JemEW4oM/giphy.gif)

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [x] Ops wrangling (automation or test improvements)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [x] If modifying code, at least one test has been added to the suite
