### PR TITLE
Fix duplicate locale prefixes in redirect_from paths

### DIFF
--- a/lib/jekyll/polyglot/patches/jekyll/site.rb
+++ b/lib/jekyll/polyglot/patches/jekyll/site.rb
@@ -206,16 +206,16 @@ module Jekyll
       # Determine document language
       doc_lang = doc.data['lang'] || derive_lang_from_path(doc) || @default_lang
 
-      # Scope user-defined redirects to document's language if non-default
       if doc_lang != @default_lang && !user_redirects.empty?
         user_redirects = user_redirects.map do |redirect_path|
-          # Normalize path to start with /
           redirect_path = "/#{redirect_path}" unless redirect_path.start_with?('/')
-          # Only prefix if not already prefixed with this language
-          if redirect_path.start_with?("/#{doc_lang}/")
-            redirect_path
+
+          if redirect_path == "/#{doc_lang}"
+            '/'
+          elsif redirect_path.start_with?("/#{doc_lang}/")
+            redirect_path.delete_prefix("/#{doc_lang}")
           else
-            "/#{doc_lang}#{redirect_path}"
+            redirect_path
           end
         end
       end

--- a/spec/jekyll/polyglot/patches/jekyll/redirect_from_spec.rb
+++ b/spec/jekyll/polyglot/patches/jekyll/redirect_from_spec.rb
@@ -1,0 +1,64 @@
+require 'jekyll'
+require 'rspec/helper'
+require 'fileutils'
+require 'tmpdir'
+
+describe 'redirect_from localization' do
+  let(:source) { Dir.mktmpdir }
+  let(:destination) { File.join(source, '_site') }
+
+  around do |example|
+    generators = Jekyll::Generator.instance_variable_get(:@children)&.dup
+
+    begin
+      require 'jekyll-redirect-from'
+      example.run
+    ensure
+      Jekyll::Generator.instance_variable_set(:@children, generators)
+    end
+  end
+
+  after do
+    FileUtils.rm_rf(source)
+  end
+
+  def write_page(filename, lang)
+    File.write(
+      File.join(source, filename),
+      <<~MARKDOWN
+        ---
+        lang: #{lang}
+        permalink: /blog/new-title/
+        redirect_from:
+          - /blog/old-title/
+        ---
+        #{lang}
+      MARKDOWN
+    )
+  end
+
+  it 'writes secondary-language redirects without duplicating the locale prefix' do
+    write_page('new-title.en.md', 'en')
+    write_page('new-title.de.md', 'de')
+
+    site = Site.new(
+      Jekyll.configuration(
+        'source'                => source,
+        'destination'           => destination,
+        'languages'             => ['en', 'de'],
+        'default_lang'          => 'en',
+        'parallel_localization' => false,
+        'url'                   => 'https://test.github.io',
+        'plugins'               => ['jekyll-redirect-from']
+      )
+    )
+    site.process
+
+    redirect = File.join(destination, 'de', 'blog', 'old-title', 'index.html')
+    duplicated = File.join(destination, 'de', 'de', 'blog', 'old-title', 'index.html')
+
+    expect(File).to exist(redirect)
+    expect(File).not_to exist(duplicated)
+    expect(File.read(redirect)).to include('https://test.github.io/de/blog/new-title/')
+  end
+end

--- a/spec/jekyll/polyglot/patches/jekyll/site_spec.rb
+++ b/spec/jekyll/polyglot/patches/jekyll/site_spec.rb
@@ -554,7 +554,7 @@ describe Site do
         expect(doc.data['redirect_from']).to include('/de/neue-url/')
       end
 
-      it 'should scope user-defined redirect_from to document language for non-default languages' do
+      it 'keeps user-defined redirects relative to non-default language destination' do
         doc = Jekyll::Document.new('test.de.md', site: @site, collection: @collection).tap do |d|
           d.data['lang'] = 'de'
           d.data['permalink'] = '/de/neue-url/'
@@ -563,9 +563,9 @@ describe Site do
 
         @site.assignPageRedirects(doc, [doc])
 
-        expect(doc.data['redirect_from']).to include('/de/alte-url/')
-        expect(doc.data['redirect_from']).to include('/de/legacy/')
-        expect(doc.data['redirect_from']).not_to include('/alte-url/')
+        expect(doc.data['redirect_from']).to include('/alte-url/')
+        expect(doc.data['redirect_from']).to include('/legacy/')
+        expect(doc.data['redirect_from']).not_to include('/de/alte-url/')
       end
 
       it 'should not prefix redirect_from for default language' do
@@ -580,18 +580,19 @@ describe Site do
         expect(doc.data['redirect_from']).to eq(['/old-url/'])
       end
 
-      it 'should not double-prefix redirects that already have language prefix' do
+      it 'removes matching language prefix from user-defined redirects' do
         doc = Jekyll::Document.new('test.de.md', site: @site, collection: @collection).tap do |d|
           d.data['lang'] = 'de'
           d.data['permalink'] = '/de/neue-url/'
-          d.data['redirect_from'] = ['/de/alte-url/', '/legacy/']
+          d.data['redirect_from'] = ['/de', '/de/alte-url/', '/legacy/']
         end
 
         @site.assignPageRedirects(doc, [doc])
 
-        expect(doc.data['redirect_from']).to include('/de/alte-url/')
-        expect(doc.data['redirect_from']).to include('/de/legacy/')
-        expect(doc.data['redirect_from']).not_to include('/de/de/alte-url/')
+        expect(doc.data['redirect_from']).to include('/')
+        expect(doc.data['redirect_from']).to include('/alte-url/')
+        expect(doc.data['redirect_from']).to include('/legacy/')
+        expect(doc.data['redirect_from']).not_to include('/de/alte-url/')
       end
     end
 


### PR DESCRIPTION
## 🔤 Polyglot PR

Fixes secondary-language `redirect_from` paths being prefixed twice during site generation. User redirects remain relative to the language destination, and an explicit matching locale prefix is stripped once.

Closes #313.

Tested with the focused specs, the suite excluding the Unix-only process-count spec, and RuboCop.

## Type of change

- [ ] Docs update (changes to the readme or a site page, no code changes)
- [ ] Ops wrangling (automation or test improvements)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Sweet release (needs a lot of work and effort)
- [ ] Something else (explain please)

### Checklists

- [x] If modifying code, at least one test has been added to the suite